### PR TITLE
Decode key string before returning

### DIFF
--- a/boto/storage_uri.py
+++ b/boto/storage_uri.py
@@ -225,7 +225,7 @@ class StorageUri(object):
         key = self.get_key(validate, headers)
         self.check_response(key, 'key', self.uri)
         return key.get_contents_as_string(headers, cb, num_cb, torrent,
-                                          version_id)
+                                          version_id).decode()
 
     def acl_class(self):
         conn = self.connect()


### PR DESCRIPTION
When key as string was being returned, it wasn't decoded, resulting
in a leading `b'` artifact in Python 3.x versions.