### PR TITLE
Ensure Unicode before concatenating strings

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -91,8 +91,6 @@ class _CallingFormat(object):
     def build_auth_path(self, bucket, key=''):
         bucket = six.ensure_text(bucket, encoding='utf-8')
         key = get_utf8able_str(key)
-        if isinstance(bucket, bytes):
-            bucket = bucket.decode('utf-8')
         path = ''
         if bucket != '':
             path = '/' + bucket

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -76,7 +76,7 @@ class _CallingFormat(object):
         return ''
 
     def build_url_base(self, connection, protocol, server, bucket, key=''):
-        url_base = '%s://' % protocol
+        url_base = '%s://' % six.ensure_text(protocol)
         url_base += self.build_host(server, bucket)
         url_base += connection.get_path(self.build_path_base(bucket, key))
         return url_base
@@ -89,6 +89,7 @@ class _CallingFormat(object):
 
     def build_auth_path(self, bucket, key=''):
         key = boto.utils.get_utf8_value(key)
+        bucket = six.ensure_text(bucket, encoding='utf-8')
         path = ''
         if bucket != '':
             path = '/' + bucket

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -88,12 +88,12 @@ class _CallingFormat(object):
         else:
             return self.get_bucket_server(server, bucket)
 
-    def build_auth_path(self, bucket, key=''):
+    def build_auth_path(self, bucket, key=u''):
         bucket = six.ensure_text(bucket, encoding='utf-8')
         key = get_utf8able_str(key)
-        path = ''
-        if bucket != '':
-            path = '/' + bucket
+        path = u''
+        if bucket != u'':
+            path = u'/' + bucket
         return path + '/%s' % urllib.parse.quote(key)
 
     def build_path_base(self, bucket, key=''):


### PR DESCRIPTION
Some strings that were being concatenated would mismatch unicode and
byte strings, which produces an error in Python 3 since it no longer
does implicit string type coercion.