### PR TITLE
Remove `strict=True` from http_client

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -807,7 +807,7 @@ class AWSAuthConnection(object):
                 sock.sendall(six.ensure_binary("\r\n"))
         else:
             sock.sendall(six.ensure_binary("\r\n"))
-        resp = http_client.HTTPResponse(sock, strict=True, debuglevel=self.debug)
+        resp = http_client.HTTPResponse(sock, debuglevel=self.debug)
         resp.begin()
 
         if resp.status != 200:


### PR DESCRIPTION
In Python 3.4, the `strict` kwarg was removed[1]. We are removing it
here too.

Alternatively, we can leave in `strict=True` for 2.x, but I chose to
remove it entirely to maintain consistent behavior across versions.

[1]: https://docs.python.org/3/library/http.client.html