### PR TITLE
Add labels function to MockBuckets to unblock unittesting with them

### DIFF
--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -283,6 +283,9 @@ class MockBucket(object):
         else:
             return '<Subresource/>'
 
+    def get_tags(self):
+      return []
+
     def new_key(self, key_name=None):
         mock_key = MockKey(self, key_name)
         self.keys[key_name] = mock_key


### PR DESCRIPTION
MockBuckets need get_tags() to be converted to a boto bucket successfully, which will be used in unittesting.