### PR TITLE
Use write_to_fd utility for writing to file in mock_storage_service

### DIFF
--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -36,6 +36,7 @@ from hashlib import md5
 from boto.utils import compute_md5
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
+from boto.utils import write_to_fd
 from boto.s3.prefix import Prefix
 from boto.compat import six
 
@@ -90,13 +91,13 @@ class MockKey(object):
                              version_id=NOT_IMPL,
                              res_download_handler=NOT_IMPL):
         data = six.ensure_binary(self.data)
-        fp.write(data)
+        write_to_fd(fp, data)
 
     def get_file(self, fp, headers=NOT_IMPL, cb=NOT_IMPL, num_cb=NOT_IMPL,
                  torrent=NOT_IMPL, version_id=NOT_IMPL,
                  override_num_retries=NOT_IMPL):
         data = six.ensure_binary(self.data)
-        fp.write(data)
+        write_to_fd(fp, data)
 
     def _handle_headers(self, headers):
         if not headers:


### PR DESCRIPTION
The fake storage service assumes that the provided `fp` is a binary stream.

In the case of using `sys.stdout` in python 3, the code will fail, since it is a text stream. The underlying `sys.stdout.buffer` should be used instead. This compatibility layer is already implemented in `write_to_fd` in `boto.utils`, so we can reuse it.