### PR TITLE
Default to V4 signature instead of V2 for S3

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -1062,21 +1062,37 @@ def detect_potential_sigv4(func):
     return _wrapper
 
 
+def get_boolean_value(string):
+    """Determine the boolean value based on the string."""
+    if string is not None:
+      if string.lower() in ('true', '1'):
+          return True
+      elif string.lower() in ('false', '0'):
+          return False
+    # For anything that did not match, we return None to determine
+    # that the value is not defined.
+    return None
+
+
+def convert_to_bool(val):
+    if val is None or isinstance(val, bool):
+        return val
+    if val.lower() == 'true':
+        return True
+    elif val.lower() == 'false':
+        return False
+    return None
+
+
 def detect_potential_s3sigv4(func):
     def _wrapper(self):
-        if os.environ.get('S3_USE_SIGV4', True):
-            return ['hmac-v4-s3']
-
-        if boto.config.get('s3', 'use-sigv4', True):
-            return ['hmac-v4-s3']
-
-        if not hasattr(self, 'host'):
-            return func(self)
-
-        # Keep the old explicit logic in case somebody was adding to the list.
-        for test in SIGV4_DETECT:
-            if test in self.host:
-                return ['hmac-v4-s3']
+        # Check if flags are explicitly set.
+        env_use_sigv4_flag = os.environ.get('S3_USE_SIGV4')
+        cfg_use_sigv4_flag = boto.config.get('s3', 'use-sigv4')
+        for flag in env_use_sigv4_flag, cfg_use_sigv4_flag:
+            if flag is not None:
+                flag = convert_to_bool(flag)
+                return ['hmac-v4-s3'] if flag else func(self)
 
         # Use default for non-aws hosts. Adding a url scheme is necessary if
         # not present for urlparse to properly function.
@@ -1089,19 +1105,10 @@ def detect_potential_s3sigv4(func):
                 netloc.endswith('amazonaws.com.cn')):
             return func(self)
 
-        # Use the default for the global endpoint
-        if netloc.endswith('s3.amazonaws.com'):
-            return func(self)
-
-        # Use the default for regions that support sigv4 and sigv2
-        if any(test in self.host for test in S3_AUTH_DETECT):
-            return func(self)
-
         # Use anonymous if enabled.
         if hasattr(self, 'anon') and self.anon:
             return func(self)
 
-        # Default to sigv4 for aws hosts outside of regions that are known
-        # to support sigv2
+        # Default to sigv4 for aws hosts
         return ['hmac-v4-s3']
     return _wrapper

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -612,8 +612,11 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # S3 does **NOT** do path normalization that SigV4 typically does.
         # Urlencode the path, **NOT** ``auth_path`` (because vhosting).
         path = urllib.parse.urlparse(http_request.path)
+        # urlparse might convert the path to unicode in python2.7.
+        # The urllib's quote function does not work well with unicode string.
+        path_str = six.ensure_str(path.path)
         # Because some quoting may have already been applied, let's back it out.
-        unquoted = urllib.parse.unquote(path.path)
+        unquoted = urllib.parse.unquote(path_str)
         # Requote, this time addressing all characters.
         encoded = urllib.parse.quote(unquoted, safe='/~')
         return encoded

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -1062,18 +1062,6 @@ def detect_potential_sigv4(func):
     return _wrapper
 
 
-def get_boolean_value(string):
-    """Determine the boolean value based on the string."""
-    if string is not None:
-      if string.lower() in ('true', '1'):
-          return True
-      elif string.lower() in ('false', '0'):
-          return False
-    # For anything that did not match, we return None to determine
-    # that the value is not defined.
-    return None
-
-
 def convert_to_bool(val):
     if val is None or isinstance(val, bool):
         return val
@@ -1090,8 +1078,8 @@ def detect_potential_s3sigv4(func):
         env_use_sigv4_flag = os.environ.get('S3_USE_SIGV4')
         cfg_use_sigv4_flag = boto.config.get('s3', 'use-sigv4')
         for flag in env_use_sigv4_flag, cfg_use_sigv4_flag:
+            flag = convert_to_bool(flag)
             if flag is not None:
-                flag = convert_to_bool(flag)
                 return ['hmac-v4-s3'] if flag else func(self)
 
         # Use default for non-aws hosts. Adding a url scheme is necessary if

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -191,12 +191,10 @@ class S3Connection(AWSAuthConnection):
             anon = boto.config.getbool('s3', 'no_sign_request', False)
         self.anon = anon
 
-        no_host_provided = False
         if host is NoHostProvided:
             host = boto.config.get('s3', 'host')
             if host is None:
                 host = self.DefaultHost
-                no_host_provided = True
 
         super(S3Connection, self).__init__(host,
                 aws_access_key_id, aws_secret_access_key,
@@ -205,13 +203,6 @@ class S3Connection(AWSAuthConnection):
                 path=path, provider=provider, security_token=security_token,
                 suppress_consec_slashes=suppress_consec_slashes,
                 validate_certs=validate_certs, profile_name=profile_name)
-        # We need to delay until after the call to ``super`` before checking
-        # to see if SigV4 is in use.
-        if no_host_provided:
-            if 'hmac-v4-s3' in self._required_auth_capability():
-                raise HostRequiredError(
-                    "When using SigV4, you must specify a 'host' parameter."
-                )
 
     @detect_potential_s3sigv4
     def _required_auth_capability(self):

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -672,6 +672,16 @@ class TestS3SigV4OptInAndOut(MockServiceWithConfigTestCase):
         fake = FakeS3Connection()
         self.assertEqual(fake._required_auth_capability(), ['nope'])
 
+    def test_sigv4_incorrect_config(self):
+        """Test that default(sigv4) is chosen if incorrect value is present."""
+        self.config = {
+            's3': {
+                'use-sigv4': 'someval',
+            },
+        }
+        fake = FakeS3Connection(host='s3.amazonaws.com')
+        self.assertEqual(fake._required_auth_capability(), ['hmac-v4-s3'])
+
     def test_sigv4_opt_in_env(self):
         # Opt-in via the ENV.
         self.environ['S3_USE_SIGV4'] = 'True'

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -33,7 +33,7 @@ class TestSignatureAlteration(AWSMockServiceTestCase):
     def test_unchanged(self):
         self.assertEqual(
             self.service_connection._required_auth_capability(),
-            ['s3']
+            ['hmac-v4-s3']
         )
 
     def test_switched(self):
@@ -126,7 +126,7 @@ class TestSigV4HostError(MockServiceWithConfigTestCase):
     def test_historical_behavior(self):
         self.assertEqual(
             self.service_connection._required_auth_capability(),
-            ['s3']
+            ['hmac-v4-s3']
         )
         self.assertEqual(self.service_connection.host, 's3.amazonaws.com')
 
@@ -140,15 +140,6 @@ class TestSigV4HostError(MockServiceWithConfigTestCase):
                 'use-sigv4': True,
             }
         }
-
-        # Should raise an error if no host is given in either the config or
-        # in connection arguments.
-        with self.assertRaises(HostRequiredError):
-            # No host+SigV4 == KABOOM
-            self.connection_class(
-                aws_access_key_id='less',
-                aws_secret_access_key='more'
-            )
 
         # Ensure passing a ``host`` in the connection args still works.
         conn = self.connection_class(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py33,py34,pypy,py37
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
AWS is going to deprecate V2 signatures for all the requests.

Currently this library uses V4 signature for all the regions which support only V4 signature, but it defaults to V2 signature for regions which support both V2 and V4.

This change is to make the V4 as the default signature. If the user wants to use V2 signature then it should be explicitly set using the `use-sigv4` flag in the `boto` config file.

Eventually we will be deprecating supporting v2 signature altogether. 