### PR TITLE
Retry on errors relating to region specification

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1207,7 +1207,7 @@ class AWSAuthConnection(object):
             )
             if retry_request:
                 return self._mexe(retry_request, sender, override_num_retries,
-                                retry_handler=retry_handler)
+                                  retry_handler=retry_handler)
 
         if response:
             # Note: a response returned here will not be readable using

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1153,7 +1153,15 @@ class AWSAuthConnection(object):
                 region = self._get_correct_s3_region(host, err.body)
 
             if region:
-                self.host = 's3.%s.amazonaws.com' % region
+                new_host = 's3.%s.amazonaws.com' % region
+                msg = 'S3 client configured to use host %s, but the' % self.host
+                msg += 'bucket you are trying to access is in %s. ' % region
+                msg += 'Please change your configuration to use %s ' % new_host
+                msg += 'to avoid multiple unnecessary redirects '
+                msg += 'and signing attempts.'
+                boto.log.debug(msg)
+
+                self.host = new_host
                 http_request.host = self._fix_host_region(host, region)
                 return self._mexe(http_request, sender, override_num_retries,
                                   retry_handler=retry_handler)

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1063,18 +1063,24 @@ class AWSAuthConnection(object):
         return HTTPRequest(method, self.protocol, host, self.port,
                            path, auth_path, params, headers, data)
 
-    def _get_s3_host(self, endpoint):
+    def _find_s3_host(self, endpoint):
         # An s3 endpoint is of the form bucket-name.s3(.{region}).amazonaws.com,
-        # where the host is everything after "s3.". Note that "s3." can also
-        # appear in bucket-name, so we need to find the last occurrence of
-        # "s3." to find the host.
-        ix = endpoint.rfind('s3.')
-        if ix != -1:
+        # where the host is everything after "bucket-name." Note that ".s3." 
+        # can also appear in bucket-name, so we need to find the last
+        # occurrence of ".s3." to find the host.
+        ix = endpoint.rfind('.s3.')
+        if ix == -1:
+            return None
+        return ix + 1
+
+    def _get_s3_host(self, endpoint):
+        ix = self._find_s3_host(endpoint)
+        if ix:
             return endpoint[ix:]
     
     def _change_s3_host(self, endpoint, new_host):
-        ix = endpoint.rfind('s3.')
-        if ix != -1:
+        ix = self._find_s3_host(endpoint)
+        if ix:
             return endpoint[:ix] + new_host
 
     def _fix_s3_endpoint_region(self, endpoint, correct_region):

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1065,7 +1065,7 @@ class AWSAuthConnection(object):
 
     def _find_s3_host(self, endpoint):
         # An s3 endpoint is of the form bucket-name.s3(.{region}).amazonaws.com,
-        # where the host is everything after "bucket-name." Note that ".s3." 
+        # where the host is everything after "bucket-name." Note that ".s3."
         # can also appear in bucket-name, so we need to find the last
         # occurrence of ".s3." to find the host.
         ix = endpoint.rfind('.s3.')
@@ -1077,7 +1077,7 @@ class AWSAuthConnection(object):
         ix = self._find_s3_host(endpoint)
         if ix:
             return endpoint[ix:]
-    
+
     def _change_s3_host(self, endpoint, new_host):
         ix = self._find_s3_host(endpoint)
         if ix:
@@ -1148,7 +1148,7 @@ class AWSAuthConnection(object):
 
         new_host = self._get_s3_host(new_endpoint)
         if new_host and new_host != self.host:
-            msg += 'This error may have arisen because your S3 host, ' 
+            msg += 'This error may have arisen because your S3 host, '
             msg += 'currently %s, is configured incorrectly. ' % self.host
             msg += 'Please change your configuration to use %s ' % new_host
             msg += 'to avoid multiple unnecessary redirects '
@@ -1186,7 +1186,7 @@ class AWSAuthConnection(object):
             params = {}
         http_request = self.build_base_http_request(method, path, auth_path,
                                                     params, headers, data, host)
-        response, err = None, None    
+        response, err = None, None
         try:
             response = self._mexe(http_request, sender, override_num_retries,
                                   retry_handler=retry_handler)
@@ -1212,7 +1212,7 @@ class AWSAuthConnection(object):
         if response:
             # Note: a response returned here will not be readable using
             # response.read(amt) if it came from an s3 request and its status
-            # code is 301 or 400. This is because response.read() is called 
+            # code is 301 or 400. This is because response.read() is called
             # above under these conditions, and response.read(amt) does not
             # return bytes after read has been called once. Make sure to check
             # for a non-error status code before calling response.read(amt)!

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1201,7 +1201,6 @@ class AWSAuthConnection(object):
             err = e
 
         status = (response or err).status
-        boto.log.debug(http_request.host)
         if http_request.host.endswith('amazonaws.com') and status in [301, 400]:
             retry_request = self._get_request_for_s3_retry(
                 http_request,

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1186,8 +1186,8 @@ class AWSAuthConnection(object):
         """
         if params is None:
             params = {}
-        http_request = self.build_base_http_request(method, path, auth_path,
-                                                    params, headers, data, host)
+        http_request = self.build_base_http_request(
+            method, path, auth_path, params, headers, data, host)
         response, err = None, None
         try:
             response = self._mexe(http_request, sender, override_num_retries,

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -316,7 +316,30 @@ class S3ResponseError(StorageResponseError):
     """
     Error in response from S3.
     """
-    pass
+    def __init__(self, status, reason, body=None):
+        self.region = None
+        self.endpoint = None
+        super(StorageResponseError, self).__init__(status, reason, body)
+
+    def startElement(self, name, attrs, connection):
+        return super(StorageResponseError, self).startElement(
+            name, attrs, connection)
+
+    def endElement(self, name, value, connection):
+        if name == 'Region':
+            self.region = value
+        elif name == 'LocationConstraint':
+            self.region = value
+        elif name == 'Endpoint':
+            self.endpoint = value
+        else:
+            return super(StorageResponseError, self).endElement(
+                name, value, connection)
+
+    def _cleanupParsedProperties(self):
+        super(StorageResponseError, self)._cleanupParsedProperties()
+        for p in ('region', 'endpoint'):
+            setattr(self, p, None)
 
 
 class GSResponseError(StorageResponseError):

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -477,9 +477,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             mocked_mexe.side_effect = [error_response]
 
             response = self.connection.make_request(
-                'HEAD',
-                '/',
-                host=self.default_host)
+                'HEAD', '/', host=self.default_host)
 
             self.assertEqual(response, error_response)
             # called_once_with does not compare equality correctly with

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -472,223 +472,281 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
         self.test_headers = [('x-amz-bucket-region', self.retry_region)]
 
     def test_non_retriable_status_returns_original_response(self):
-        error_response = self.create_response(self.non_retriable_code)
-        self.connection._mexe = mock.Mock(side_effect=[error_response])
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            error_response = self.create_response(self.non_retriable_code)
+            mocked_mexe.side_effect = [error_response]
 
-        response = self.connection.make_request(
-            'HEAD', '/', host=self.default_host)
+            response = self.connection.make_request(
+                'HEAD',
+                '/',
+                host=self.default_host)
 
-        self.assertEqual(response, error_response)
-        self.assertEqual(self.connection._mexe.call_count, 1)
+            self.assertEqual(response, error_response)
+            # called_once_with does not compare equality correctly with
+            # HTTPResponse objects.
+            self.assertEqual(mocked_mexe.call_count, 1)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                self.default_host
+            )
+
 
     def test_non_retriable_host_returns_original_response(self):
         for code in self.retry_status_codes:
-            error_response = self.create_response(code)
-            self.connection._mexe = mock.Mock(side_effect=[error_response])
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                error_response = self.create_response(code)
+                mocked_mexe.side_effect = [error_response]
 
-            response = self.connection.make_request(
-                'HEAD', '/', host='bucket.some-other-provider.com')
+                other_host = 'bucket.some-other-provider.com'
+                response = self.connection.make_request(
+                    'HEAD', '/', host=other_host)
 
-            self.assertEqual(response, error_response)
-            self.assertEqual(self.connection._mexe.call_count, 1)
+                self.assertEqual(response, error_response)
+                self.assertEqual(mocked_mexe.call_count, 1)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    other_host
+                )
 
     def test_non_retriable_status_raises_original_exception(self):
-        error_response = S3ResponseError(self.non_retriable_code, 'reason')
-        self.connection._mexe = mock.Mock(side_effect=[error_response])
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            error_response = S3ResponseError(self.non_retriable_code, 'reason')
+            mocked_mexe.side_effect = [error_response]
 
-        with self.assertRaises(S3ResponseError) as cm:
-            self.connection.make_request('HEAD', '/', host=self.default_host)
+            with self.assertRaises(S3ResponseError) as cm:
+                self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
 
             self.assertEqual(cm.exception, error_response)
-            self.assertEqual(self.connection._mexe.call_count, 1)
+            self.assertEqual(mocked_mexe.call_count, 1)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                self.default_host
+            )
 
     def test_non_retriable_host_raises_original_exception(self):
-        error_response = S3ResponseError(self.non_retriable_code, 'reason')
-        self.connection._mexe = mock.Mock(side_effect=[error_response])
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            error_response = S3ResponseError(self.non_retriable_code, 'reason')
+            mocked_mexe.side_effect = [error_response]
 
-        with self.assertRaises(S3ResponseError) as cm:
-            self.connection.make_request(
-                'HEAD', '/', host='bucket.some-other-provider.com')
+            other_host = 'bucket.some-other-provider.com'
+            with self.assertRaises(S3ResponseError) as cm:
+                self.connection.make_request(
+                    'HEAD', '/', host=other_host)
 
             self.assertEqual(cm.exception, error_response)
-            self.assertEqual(self.connection._mexe.call_count, 1)
+            self.assertEqual(mocked_mexe.call_count, 1)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                other_host
+            )
 
     def test_response_retries_from_callable_headers(self):
         for code in self.retry_status_codes:
-            self.connection._mexe = mock.Mock(side_effect=[
-                self.create_response(code, header=self.test_headers),
-                self.success_response
-            ])
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    self.create_response(code, header=self.test_headers),
+                    self.success_response
+                ]
 
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_retry_changes_host_with_region(self):
-        # Assume 400 with callable headers results uses the same url
-        # manipulation as all of the other successful cases.
-        self.connection._mexe = mock.Mock(side_effect=[
-            self.create_response(400, header=self.test_headers),
-            self.success_response
-        ])
-
-        response = self.connection.make_request(
-            'HEAD', '/', host=self.default_host)
-
-        self.assertEqual(response, self.success_response)
-        self.assertEqual(
-            self.connection._mexe.call_args.args[0].host,
-            self.default_retried_host
-        )
-
-    def test_retry_changes_host_with_multiple_s3_occurrences(self):
-        # Assume 400 with callable headers results uses the same url
-        # manipulation as all of the other successful cases.
-        self.connection._mexe = mock.Mock(side_effect=[
-            self.create_response(400, header=self.test_headers),
-            self.success_response
-        ])
-
-        response = self.connection.make_request(
-            'HEAD', '/', host='a.s3.a.s3.amazonaws.com')
-
-        self.assertEqual(response, self.success_response)
-        self.assertEqual(
-            self.connection._mexe.call_args.args[0].host,
-            'a.s3.a.s3.us-east-2.amazonaws.com'
-        )
-
-    def test_retry_changes_host_with_s3_in_region(self):
-        # Assume 400 with callable headers results uses the same url
-        # manipulation as all of the other successful cases.
-        self.connection._mexe = mock.Mock(side_effect=[
-            self.create_response(400, header=self.test_headers),
-            self.success_response
-        ])
-
-        response = self.connection.make_request(
-            'HEAD', '/', host='bucket.s3.asdf-s3.amazonaws.com')
-
-        self.assertEqual(response, self.success_response)
-        self.assertEqual(
-            self.connection._mexe.call_args.args[0].host,
-            self.default_retried_host
-        )
-
-    def test_response_body_parsed_for_region(self):
-        for code, body in ERRORS_WITH_REGION_IN_BODY:
-            self.connection._mexe = mock.Mock(side_effect=[
-                self.create_response(code, body=body),
-                self.success_response
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_error_body_parsed_for_region(self):
-        for code, body in ERRORS_WITH_REGION_IN_BODY:
-            self.connection._mexe = mock.Mock(side_effect=[
-                S3ResponseError(code, 'reason', body=body),
-                self.success_response
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_response_without_region_header_retries_from_bucket_head(self):
-        for code in self.retry_status_codes:
-            self.connection._mexe = mock.Mock(side_effect=[
-                self.create_response(code),
-                self.create_response(200, header=self.test_headers),
-                self.success_response
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_response_body_without_region_sends_bucket_head(self):
-        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
-            self.connection._mexe = mock.Mock(side_effect=[
-                self.create_response(code, body=body),
-                self.create_response(200, header=self.test_headers),
-                self.success_response
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_error_body_without_region_retries_from_bucket_head_request(self):
-        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
-            self.connection._mexe = mock.Mock(side_effect=[
-                S3ResponseError(code, 'reason', body=body),
-                self.create_response(200, header=self.test_headers),
-                self.success_response
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, self.success_response)
-            self.assertEqual(
-                self.connection._mexe.call_args.args[0].host,
-                self.default_retried_host
-            )
-
-    def test_retry_head_request_lacks_region_returns_original_response(self):
-        for code in self.retry_status_codes:
-            error_response = self.create_response(code)
-            self.connection._mexe = mock.Mock(side_effect=[
-                error_response,
-                self.create_response(200, header=[])  # no region in header.
-            ])
-
-            response = self.connection.make_request(
-                'HEAD', '/', host=self.default_host)
-
-            self.assertEqual(response, error_response)
-
-    def test_retry_head_request_lacks_region_raises_original_exception(self):
-        for code in self.retry_status_codes:
-            error_response = S3ResponseError(code, 'reason')
-            self.connection._mexe = mock.Mock(side_effect=[
-                error_response,
-                self.create_response(200, header=[])
-            ])
-
-            with self.assertRaises(S3ResponseError) as cm:
                 response = self.connection.make_request(
                     'HEAD', '/', host=self.default_host)
 
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 2)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_retry_changes_host_with_region(self):
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            # Assume 400 with callable headers results uses the same url
+            # manipulation as all of the other successful cases.
+            mocked_mexe.side_effect = [
+                self.create_response(400, header=self.test_headers),
+                self.success_response
+            ]
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(mocked_mexe.call_count, 2)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_retry_changes_host_with_multiple_s3_occurrences(self):
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            # Assume 400 with callable headers results uses the same url
+            # manipulation as all of the other successful cases.
+            mocked_mexe.side_effect = [
+                self.create_response(400, header=self.test_headers),
+                self.success_response
+            ]
+
+            response = self.connection.make_request(
+                'HEAD', '/', host='a.s3.a.s3.amazonaws.com')
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(mocked_mexe.call_count, 2)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                'a.s3.a.s3.us-east-2.amazonaws.com'
+            )
+
+    def test_retry_changes_host_with_s3_in_region(self):
+        with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+            # Assume 400 with callable headers results uses the same url
+            # manipulation as all of the other successful cases.
+            mocked_mexe.side_effect = [
+                self.create_response(400, header=self.test_headers),
+                self.success_response
+            ]
+
+            response = self.connection.make_request(
+                'HEAD', '/', host='bucket.s3.asdf-s3.amazonaws.com')
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(mocked_mexe.call_count, 2)
+            self.assertEqual(
+                mocked_mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_response_body_parsed_for_region(self):
+        for code, body in ERRORS_WITH_REGION_IN_BODY:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    self.create_response(code, body=body),
+                    self.success_response
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 2)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_error_body_parsed_for_region(self):
+        for code, body in ERRORS_WITH_REGION_IN_BODY:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    S3ResponseError(code, 'reason', body=body),
+                    self.success_response
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 2)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_response_without_region_header_retries_from_bucket_head(self):
+        for code in self.retry_status_codes:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    self.create_response(code),
+                    self.create_response(200, header=self.test_headers),
+                    self.success_response
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 3)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_response_body_without_region_sends_bucket_head(self):
+        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    self.create_response(code, body=body),
+                    self.create_response(200, header=self.test_headers),
+                    self.success_response
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 3)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_error_body_without_region_retries_from_bucket_head_request(self):
+        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                mocked_mexe.side_effect = [
+                    S3ResponseError(code, 'reason', body=body),
+                    self.create_response(200, header=self.test_headers),
+                    self.success_response
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, self.success_response)
+                self.assertEqual(mocked_mexe.call_count, 3)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_retried_host
+                )
+
+    def test_retry_head_request_lacks_region_returns_original_response(self):
+        for code in self.retry_status_codes:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                error_response = self.create_response(code)
+                mocked_mexe.side_effect = [
+                    error_response,
+                    self.create_response(200, header=[])  # no region in header.
+                ]
+
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(response, error_response)
+                self.assertEqual(mocked_mexe.call_count, 2)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_host
+                )
+
+    def test_retry_head_request_lacks_region_raises_original_exception(self):
+        for code in self.retry_status_codes:
+            with mock.patch.object(self.connection, '_mexe') as mocked_mexe:
+                error_response = S3ResponseError(code, 'reason')
+                mocked_mexe.side_effect = [
+                    error_response,
+                    self.create_response(200, header=[])
+                ]
+
+                with self.assertRaises(S3ResponseError) as cm:
+                    response = self.connection.make_request(
+                        'HEAD', '/', host=self.default_host)
+
                 self.assertEqual(cm.exception, error_response)
+                self.assertEqual(mocked_mexe.call_count, 2)
+                self.assertEqual(
+                    mocked_mexe.call_args.args[0].host,
+                    self.default_host
+                )
 
 
 if __name__ == "__main__":

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -19,10 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+from tests.compat import mock
 from tests.compat import unittest
 from tests.unit import AWSMockServiceTestCase
 from tests.unit import MockServiceWithConfigTestCase
 
+from boto.connection import AWSAuthConnection
 from boto.s3.connection import S3Connection, HostRequiredError
 from boto.s3.connection import S3ResponseError, Bucket
 
@@ -396,428 +398,297 @@ class TestHeadBucket(AWSMockServiceTestCase):
         self.assertEqual(err.error_code, None)
         self.assertEqual(err.message, '')
 
+RETRY_REGION_BYTES = b'us-east-2'
 
-class TestGetS3Host(AWSMockServiceTestCase):
-    connection_class = S3Connection
+AUTHORIZATION_HEADER_MALFORMED=(
+    b'<Error><Code>AuthorizationHeaderMalformed</Code><Message>The '
+    b'authorization header is malformed; the region \'us-east-1\' '
+    b'is wrong; expecting \'%s\'</Message>'
+    b'<Region>us-east-2</Region><RequestId>asdf</RequestId>'
+    b'<HostId>asdf</HostId></Error>'
+) % RETRY_REGION_BYTES
 
-    def test_get_s3_host_no_region(self):
-        endpoint = 'a.s3.amazonaws.com'
-        host = self.service_connection._get_s3_host(endpoint)
-        self.assertEqual(host, 's3.amazonaws.com')
+ILLEGAL_LOCATION_CONSTRAINT_SPECIFIED_REGION = (
+    b'<Error><Code>IllegalLocationConstraintException</Code>'
+    b'<Message>The %s location constraint is incompatible '
+    b'for the region specific endpoint this request was sent to.'
+    b'</Message><RequestId>asdf</RequestId>'
+    b'<HostId>asdf</HostId></Error>'
+) % RETRY_REGION_BYTES
 
-    def test_get_s3_host_with_region(self):
-        endpoint = 'a.s3.us-east-2.amazonaws.com'
-        host = self.service_connection._get_s3_host(endpoint)
-        self.assertEqual(host, 's3.us-east-2.amazonaws.com')
+PERMANENT_REDIRECT = (
+    b'<Error><Code>PermanentRedirect</Code><Message>The bucket you '
+    b'are attempting to access must be addressed using the '
+    b'specified endpoint. Please send all future requests to this '
+    b'endpoint.</Message><Endpoint>'
+    b'bucket.s3.%s.amazonaws.com</Endpoint>'
+    b'<Bucket>bucket</Bucket><RequestId>asdf</RequestId>'
+    b'<HostId>asdf</HostId></Error>'
+) % RETRY_REGION_BYTES
 
-    def test_get_s3_host_multiple_s3_occurrences(self):
-        endpoint = 'a.s3.a.s3.amazonaws.com'
-        host = self.service_connection._get_s3_host(endpoint)
-        self.assertEqual(host, 's3.amazonaws.com')
+ILLEGAL_LOCATION_CONSTRAINT_UNSPECIFIED_REGION = (
+    b'<Error><Code>IllegalLocationConstraintException</Code>'
+    b'<Message>The unspecified location constraint is incompatible '
+    b'for the region specific endpoint this request was sent to.'
+    b'</Message><RequestId>asdf</RequestId>'
+    b'<HostId>asdf</HostId></Error>'
+)
 
-    def test_get_s3_host_s3_in_region(self):
-        endpoint = 'a.s3.asdf-s3.amazonaws.com'
-        host = self.service_connection._get_s3_host(endpoint)
-        self.assertEqual(host, 's3.asdf-s3.amazonaws.com')
+# This output cannot come from the API, but it's here to test
+# that strings not matching the regex handling this error are
+# handled gracefully.
+ILLEGAL_LOCATION_CONSTRAINT_MALFORMED = (
+    b'<Error><Code>IllegalLocationConstraintException</Code>'
+    b'<Message>Some random string.</Message><RequestId>asdf</RequestId>'
+    b'<HostId>asdf</HostId></Error>'
+)
 
-    def test_get_s3_host_no_s3(self):
-        endpoint = 'a.some-other-storage-service.com'
-        host = self.service_connection._get_s3_host(endpoint)
-        self.assertIsNone(host)
+ERRORS_WITH_REGION_IN_BODY = (
+    (400, AUTHORIZATION_HEADER_MALFORMED),
+    (400, ILLEGAL_LOCATION_CONSTRAINT_SPECIFIED_REGION),
+    (301, PERMANENT_REDIRECT)
+)
 
-
-class TestChangeS3Host(AWSMockServiceTestCase):
-    connection_class = S3Connection
-    new_host = 'test-host'
-
-    def test_change_s3_host_no_region(self):
-        endpoint = 'a.s3.amazonaws.com'
-        host = self.service_connection._change_s3_host(endpoint, self.new_host)
-        self.assertEqual(host, 'a.test-host')
-
-    def test_change_s3_host_with_region(self):
-        endpoint = 'a.s3.us-east-2.amazonaws.com'
-        host = self.service_connection._change_s3_host(endpoint, self.new_host)
-        self.assertEqual(host, 'a.test-host')
-
-    def test_change_s3_host_multiple_s3_occurrences(self):
-        endpoint = 'a.s3.a.s3.amazonaws.com'
-        host = self.service_connection._change_s3_host(endpoint, self.new_host)
-        self.assertEqual(host, 'a.s3.a.test-host')
-
-    def test_change_s3_host_s3_in_region(self):
-        endpoint = 'a.s3.asdf-s3.amazonaws.com'
-        host = self.service_connection._change_s3_host(endpoint, self.new_host)
-        self.assertEqual(host, 'a.test-host')
-
-    def test_get_s3_host_no_s3(self):
-        endpoint = 'a.some-other-storage-service.com'
-        host = self.service_connection._change_s3_host(endpoint, self.new_host)
-        self.assertIsNone(host)
+ERRORS_WITHOUT_REGION_IN_BODY = (
+    (400, ILLEGAL_LOCATION_CONSTRAINT_UNSPECIFIED_REGION),
+    (400, ILLEGAL_LOCATION_CONSTRAINT_MALFORMED)
+)
 
 
-class TestFixS3EndpointRegion(AWSMockServiceTestCase):
-    connection_class = S3Connection
-
-    def test_fix_s3_endpoint_region_no_endpoint(self):
-        new_endpoint = self.service_connection._fix_s3_endpoint_region(
-            None, 'eu-west-1')
-        self.assertIsNone(new_endpoint)
-
-    def test_fix_s3_endpoint_region_no_region(self):
-        endpoint = 'a.s3.us-east-2.amazonaws.com'
-        new_endpoint = self.service_connection._fix_s3_endpoint_region(
-            endpoint, None)
-        self.assertIsNone(new_endpoint)
-
-    def test_fix_s3_endpoint_region_region_in_endpoint(self):
-        endpoint = 'a.s3.us-east-2.amazonaws.com'
-        new_region = 'ap-south-1'
-        new_endpoint = self.service_connection._fix_s3_endpoint_region(
-            endpoint, new_region)
-        self.assertEqual(new_endpoint, 'a.s3.ap-south-1.amazonaws.com')
-
-    def test_fix_s3_endpoint_region_no_region_in_endpoint(self):
-        endpoint = 'a.s3.amazonaws.com'
-        new_region = 'ap-south-1'
-        new_endpoint = self.service_connection._fix_s3_endpoint_region(
-            endpoint, new_region)
-        self.assertEqual(new_endpoint, 'a.s3.ap-south-1.amazonaws.com')
-
-    def test_fix_s3_endpoint_region_non_s3_endpoint(self):
-        endpoint = 'a.some-other-storage-service.com'
-        new_region = 'ap-south-1'
-        new_endpoint = self.service_connection._fix_s3_endpoint_region(
-            endpoint, new_region)
-        self.assertIsNone(new_endpoint)
-
-
-class TestGetCorrectS3EndpointFromResponse(AWSMockServiceTestCase):
-    connection_class = S3Connection
+class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
 
     def setUp(self):
-        super(TestGetCorrectS3EndpointFromResponse, self).setUp()
+        self.connection = AWSAuthConnection('s3.amazonaws.com')
 
-        # this function is really long and does not fit on one line below.
-        sc = self.service_connection
-        self.endpoint_alias = sc._get_correct_s3_endpoint_from_response
+        self.non_retriable_code = 404
+        self.retry_status_codes = [301, 400]
+        self.success_response = self.create_response(200)
 
-    def build_request(self, method='HEAD', path='/', auth_path='/', params=None,
-                      headers=None, data=None, host=''):
-        """Add defaults for less noise in the tests."""
-        return self.service_connection.build_base_http_request(
-            method, path, auth_path,
-            params, headers, data, host)
-
-    def test_callable_get_header_has_region(self):
-        host = 'bucket.s3.amazonaws.com'
-        headers = {'x-amz-bucket-region': 'us-east-2'}
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            S3ResponseError('status', 'reason'),
-            headers.get
+        self.default_host = 'bucket.s3.amazonaws.com'
+        self.retry_region = RETRY_REGION_BYTES.decode('utf-8')
+        self.default_retried_host = (
+            'bucket.s3.%s.amazonaws.com' % self.retry_region
         )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+        self.test_headers = [('x-amz-bucket-region', self.retry_region)]
 
-    def test_callable_get_header_no_region_checks_error(self):
-        host = 'bucket.s3.amazonaws.com'
-        headers = {}
-        body = '<Region>us-east-2</Region>'
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            headers.get
-        )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+    def test_non_retriable_status_returns_original_response(self):
+        error_response = self.create_response(self.non_retriable_code)
+        self.connection._mexe = mock.Mock(side_effect=[error_response])
 
-    def test_uses_parsed_region(self):
-        host = 'bucket.s3.amazonaws.com'
-        body = '<Region>us-east-2</Region>'
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+        response = self.connection.make_request(
+            'HEAD', '/', host=self.default_host)
 
-    def test_uses_parsed_location_constraint(self):
-        host = 'bucket.s3.amazonaws.com'
-        body = '<LocationConstraint>us-east-2</LocationConstraint>'
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+        self.assertEqual(response, error_response)
+        self.assertEqual(self.connection._mexe.call_count, 1)
 
-    def test_illegal_constraint_exception_matches_regex(self):
-        host = 'bucket.s3.amazonaws.com'
-        body = (
-            '<Error><Code>IllegalLocationConstraintException</Code><Message>'
-            'The us-east-2 location constraint is incompatible for the region '
-            'specific endpoint this request was sent to.</Message><RequestId>'
-            'asdf</RequestId><HostId>asdf</HostId></Error>'
-        )
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+    def test_non_retriable_host_returns_original_response(self):
+        for code in self.retry_status_codes:
+            error_response = self.create_response(code)
+            self.connection._mexe = mock.Mock(side_effect=[error_response])
 
-    def test_error_parsed_endpoint(self):
-        host = 'bucket.s3.amazonaws.com'
-        body = '<Endpoint>use-this-instead</Endpoint>'
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertEqual(endpoint, 'use-this-instead')
+            response = self.connection.make_request(
+                'HEAD', '/', host='bucket.some-other-provider.com')
 
-    def test_illegal_constraint_exception_matches_regex_unspecified(self):
-        self.set_http_response(status_code=200)
-        host = 'bucket.s3.amazonaws.com'
-        body = (
-            '<Error><Code>IllegalLocationConstraintException</Code><Message>'
-            'The unspecified location constraint is incompatible for the '
-            'region specific endpoint this request was sent to.</Message>'
-            '<RequestId>asdf</RequestId><HostId>asdf</HostId></Error>'
-        )
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
+            self.assertEqual(response, error_response)
+            self.assertEqual(self.connection._mexe.call_count, 1)
 
-    def test_illegal_constraint_exception_does_not_match_regex(self):
-        self.set_http_response(status_code=200)
-        host = 'bucket.s3.amazonaws.com'
-        body = (
-            '<Error><Code>IllegalLocationConstraintException</Code><Message>'
-            'some string</Message><RequestId>asdf</RequestId><HostId>asdf'
-            '</HostId></Error>'
-        )
-        err = S3ResponseError(400, 'reason', body=body)
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
+    def test_non_retriable_status_raises_original_exception(self):
+        error_response = S3ResponseError(self.non_retriable_code, 'reason')
+        self.connection._mexe = mock.Mock(side_effect=[error_response])
 
-    def test_bucket_head_request_has_region(self):
-        self.set_http_response(
-            status_code=200,
-            header=[('x-amz-bucket-region', 'us-east-2')]
-        )
+        with self.assertRaises(S3ResponseError) as cm:
+            self.connection.make_request('HEAD', '/', host=self.default_host)
 
-        host = 'bucket.s3.amazonaws.com'
-        err = S3ResponseError(400, 'reason')
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertEqual(endpoint, 'bucket.s3.us-east-2.amazonaws.com')
+            self.assertEqual(cm.exception, error_response)
+            self.assertEqual(self.connection._mexe.call_count, 1)
 
-    def test_bucket_head_request_does_not_have_region(self):
-        self.set_http_response(status_code=200)
+    def test_non_retriable_host_raises_original_exception(self):
+        error_response = S3ResponseError(self.non_retriable_code, 'reason')
+        self.connection._mexe = mock.Mock(side_effect=[error_response])
 
-        host = 'bucket.s3.amazonaws.com'
-        err = S3ResponseError(400, 'reason')
-        endpoint = self.endpoint_alias(
-            self.build_request(host=host),
-            err,
-            None
-        )
-        self.assertIsNone(endpoint)
+        with self.assertRaises(S3ResponseError) as cm:
+            self.connection.make_request(
+                'HEAD', '/', host='bucket.some-other-provider.com')
 
+            self.assertEqual(cm.exception, error_response)
+            self.assertEqual(self.connection._mexe.call_count, 1)
 
-class TestChangeS3HostFromError(AWSMockServiceTestCase):
-    connection_class = S3Connection
+    def test_response_retries_from_callable_headers(self):
+        for code in self.retry_status_codes:
+            self.connection._mexe = mock.Mock(side_effect=[
+                self.create_response(code, header=self.test_headers),
+                self.success_response
+            ])
 
-    def setUp(self):
-        super(TestChangeS3HostFromError, self).setUp()
-        self.request = self.service_connection.build_base_http_request(
-            'GET', '/', '/',
-            None, None, '', 'bucket.s3.amazonaws.com')
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
 
-    def test_endpoint_not_none_changes_request(self):
-        correct_endpoint = 'bucket.s3.us-east-2.amazonaws.com'
-        self.service_connection._get_correct_s3_endpoint_from_response = (
-            lambda x, y, z: correct_endpoint
-        )
-
-        new_request = self.service_connection._change_s3_host_from_error(
-            self.request,
-            None
-        )
-
-        self.assertEqual(new_request.host, correct_endpoint)
-
-    def test_endpoint_none_returns_none(self):
-        self.service_connection._get_correct_s3_endpoint_from_response = (
-            lambda x, y, z: None
-        )
-
-        new_request = self.service_connection._change_s3_host_from_error(
-            self.request,
-            None
-        )
-
-        self.assertIsNone(new_request)
-
-
-class TestGetRequestForS3Retry(AWSMockServiceTestCase):
-    connection_class = S3Connection
-
-    def test_translate_response_to_error_with_body(self):
-        http_request = 'http_request'
-        body_bytes = b'<Error></Error>'
-        body_decoded = '<Error></Error>'
-        response = self.create_response(
-            400,
-            reason='reason',
-            header=[('test', 'header')],
-            body=body_bytes
-        )
-
-        def validate_function_args(request, error, get_header=None):
-            self.assertEqual(request, http_request)
-            self.assertEqual(response.status, error.status)
-            self.assertEqual(response.reason, error.reason)
-            self.assertEqual(body_decoded, error.body)
-            self.assertTrue(callable(get_header))
-
-        self.service_connection._change_s3_host_from_error = (
-            validate_function_args
-        )
-
-        self.service_connection._get_request_for_s3_retry(
-            http_request, response, None)
-
-    def test_translate_response_to_error_without_body(self):
-        http_request = 'http_request'
-        response = self.create_response(400, reason='reason')
-
-        def validate_function_args(request, error, get_header=None):
-            self.assertEqual(request, http_request)
-            self.assertEqual(response.status, error.status)
-            self.assertEqual(response.reason, error.reason)
-            self.assertTrue(callable(get_header))
-
-        self.service_connection._change_s3_host_from_error = (
-            validate_function_args
-        )
-
-        self.service_connection._get_request_for_s3_retry(
-            http_request, response, None)
-
-    def test_response_passes_error(self):
-        http_request = 'http_request'
-        err = S3ResponseError(400, 'reason', '<Error></Error>')
-
-        def validate_function_args(request, error, get_header=None):
-            self.assertEqual(request, http_request)
-            self.assertEqual(error, err)
-            self.assertFalse(callable(get_header))
-
-        self.service_connection._change_s3_host_from_error = (
-            validate_function_args
-        )
-
-        self.service_connection._get_request_for_s3_retry(
-            http_request, None, err)
-
-
-class TestMakeRequestRegionRetry(AWSMockServiceTestCase):
-    connection_class = S3Connection
-
-    def _mock_retry_request(self, request, response, error):
-        # for the methods that test the retry logic with a response, not an
-        # error, ensure future requests succeed. The functions testing the
-        # error logic overwrite this in _mexe_mock.
-        self.set_http_response(200)
-        return request
-
-    def setUp(self):
-        super(TestMakeRequestRegionRetry, self).setUp()
-
-        self.retry_codes = [301, 400]
-        self.service_connection._get_request_for_s3_retry = (
-            self._mock_retry_request
-        )
-
-    def test_aws_response_retry_status_codes(self):
-        for code in self.retry_codes:
-            self.set_http_response(code)
-            response = self.service_connection.make_request(
-                'HEAD', bucket='bucket')
-
-            self.assertEqual(response.status, 200)
-
-    def test_aws_response_other_status_no_retry(self):
-        self.set_http_response(404)
-        response = self.service_connection.make_request(
-            'HEAD', bucket='bucket')
-
-        self.assertEqual(response.status, 404)
-
-    def test_retry_request_is_none_returns_original_response(self):
-        self.service_connection._get_request_for_s3_retry = (
-            lambda *args: None
-        )
-
-        for code in self.retry_codes:
-            self.set_http_response(code)
-            response = self.service_connection.make_request(
-                'HEAD', bucket='bucket')
-
-            self.assertEqual(response.status, code)
-
-    def _mexe_mock(self, code):
-        def mock_function_using_code(*args, **kwargs):
-            # future, retried, calls should have a different status code
-            # so that whether or not a retry has occured is detectable.
-            self.service_connection._mexe = (
-                lambda *args, **kwargs: self.create_response(200)
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
             )
-            raise S3ResponseError(code, 'reason')
-        return mock_function_using_code
 
-    def test_aws_exception_retry_status_code(self):
-        for code in self.retry_codes:
-            self.service_connection._mexe = self._mexe_mock(code)
+    def test_retry_changes_host_with_region(self):
+        # Assume 400 with callable headers results uses the same url
+        # manipulation as all of the other successful cases.
+        self.connection._mexe = mock.Mock(side_effect=[
+            self.create_response(400, header=self.test_headers),
+            self.success_response
+        ])
 
-            response = self.service_connection.make_request(
-                'HEAD', bucket='bucket')
+        response = self.connection.make_request(
+            'HEAD', '/', host=self.default_host)
 
-            self.assertEqual(response.status, 200)
-
-    def test_aws_exception_other_status_raises_error(self):
-        self.service_connection._mexe = self._mexe_mock(404)
-
-        with self.assertRaises(S3ResponseError):
-            response = self.service_connection.make_request(
-                'HEAD', bucket='bucket')
-
-    def test_retry_request_is_none_raises_original_error(self):
-        self.service_connection._get_request_for_s3_retry = (
-            lambda *args: None
+        self.assertEqual(response, self.success_response)
+        self.assertEqual(
+            self.connection._mexe.call_args.args[0].host,
+            self.default_retried_host
         )
 
-        for code in self.retry_codes:
-            self.service_connection._mexe = self._mexe_mock(code)
+    def test_retry_changes_host_with_multiple_s3_occurrences(self):
+        # Assume 400 with callable headers results uses the same url
+        # manipulation as all of the other successful cases.
+        self.connection._mexe = mock.Mock(side_effect=[
+            self.create_response(400, header=self.test_headers),
+            self.success_response
+        ])
 
-            with self.assertRaises(S3ResponseError):
-                response = self.service_connection.make_request(
-                    'HEAD', bucket='bucket')
+        response = self.connection.make_request(
+            'HEAD', '/', host='a.s3.a.s3.amazonaws.com')
+
+        self.assertEqual(response, self.success_response)
+        self.assertEqual(
+            self.connection._mexe.call_args.args[0].host,
+            'a.s3.a.s3.us-east-2.amazonaws.com'
+        )
+
+    def test_retry_changes_host_with_s3_in_region(self):
+        # Assume 400 with callable headers results uses the same url
+        # manipulation as all of the other successful cases.
+        self.connection._mexe = mock.Mock(side_effect=[
+            self.create_response(400, header=self.test_headers),
+            self.success_response
+        ])
+
+        response = self.connection.make_request(
+            'HEAD', '/', host='bucket.s3.asdf-s3.amazonaws.com')
+
+        self.assertEqual(response, self.success_response)
+        self.assertEqual(
+            self.connection._mexe.call_args.args[0].host,
+            self.default_retried_host
+        )
+
+    def test_response_body_parsed_for_region(self):
+        for code, body in ERRORS_WITH_REGION_IN_BODY:
+            self.connection._mexe = mock.Mock(side_effect=[
+                self.create_response(code, body=body),
+                self.success_response
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_error_body_parsed_for_region(self):
+        for code, body in ERRORS_WITH_REGION_IN_BODY:
+            self.connection._mexe = mock.Mock(side_effect=[
+                S3ResponseError(code, 'reason', body=body),
+                self.success_response
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_response_without_region_header_retries_from_bucket_head(self):
+        for code in self.retry_status_codes:
+            self.connection._mexe = mock.Mock(side_effect=[
+                self.create_response(code),
+                self.create_response(200, header=self.test_headers),
+                self.success_response
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_response_body_without_region_sends_bucket_head(self):
+        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
+            self.connection._mexe = mock.Mock(side_effect=[
+                self.create_response(code, body=body),
+                self.create_response(200, header=self.test_headers),
+                self.success_response
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_error_body_without_region_retries_from_bucket_head_request(self):
+        for code, body in ERRORS_WITHOUT_REGION_IN_BODY:
+            self.connection._mexe = mock.Mock(side_effect=[
+                S3ResponseError(code, 'reason', body=body),
+                self.create_response(200, header=self.test_headers),
+                self.success_response
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, self.success_response)
+            self.assertEqual(
+                self.connection._mexe.call_args.args[0].host,
+                self.default_retried_host
+            )
+
+    def test_retry_head_request_lacks_region_returns_original_response(self):
+        for code in self.retry_status_codes:
+            error_response = self.create_response(code)
+            self.connection._mexe = mock.Mock(side_effect=[
+                error_response,
+                self.create_response(200, header=[])  # no region in header.
+            ])
+
+            response = self.connection.make_request(
+                'HEAD', '/', host=self.default_host)
+
+            self.assertEqual(response, error_response)
+
+    def test_retry_head_request_lacks_region_raises_original_exception(self):
+        for code in self.retry_status_codes:
+            error_response = S3ResponseError(code, 'reason')
+            self.connection._mexe = mock.Mock(side_effect=[
+                error_response,
+                self.create_response(200, header=[])
+            ])
+
+            with self.assertRaises(S3ResponseError) as cm:
+                response = self.connection.make_request(
+                    'HEAD', '/', host=self.default_host)
+
+                self.assertEqual(cm.exception, error_response)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -23,7 +23,6 @@ import os
 import socket
 
 from tests.compat import mock, unittest
-from tests.unit import AWSMockServiceTestCase
 from httpretty import HTTPretty
 
 from boto import UserAgent

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -23,6 +23,7 @@ import os
 import socket
 
 from tests.compat import mock, unittest
+from tests.unit import AWSMockServiceTestCase
 from httpretty import HTTPretty
 
 from boto import UserAgent


### PR DESCRIPTION
After AWS's change to V4 signatures, requests with an incorrectly specified region return an error. This PR uses information in those errors to retry requests with the correct region.