### PR TITLE
Fix tests

### DIFF
--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -19,14 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import errno
-import httplib
 import os
 import random
 import re
 import socket
 import time
-import urlparse
 from hashlib import md5
+
+import six.moves.http_client as httplib
+from six.moves import urllib as urlparse
+
 from boto import config, UserAgent
 from boto.connection import AWSAuthConnection
 from boto.exception import InvalidUriError

--- a/boto/s3/resumable_download_handler.py
+++ b/boto/s3/resumable_download_handler.py
@@ -19,11 +19,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import errno
-import httplib
 import os
 import re
 import socket
 import time
+
+import six.moves.http_client as httplib
+
 import boto
 from boto import config, storage_uri_for_key
 from boto.connection import AWSAuthConnection

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1
 mock==1.0.1
+six

--- a/tests/devpay/test_s3.py
+++ b/tests/devpay/test_s3.py
@@ -38,7 +38,7 @@ AMAZON_USER_TOKEN = '{UserToken}...your token here...'
 DEVPAY_HEADERS = { 'x-amz-security-token': AMAZON_USER_TOKEN }
 
 def test():
-    print '--- running S3Connection tests (DevPay) ---'
+    print('--- running S3Connection tests (DevPay) ---')
     c = S3Connection()
     # create a new, empty bucket
     bucket_name = 'test-%d' % int(time.time())
@@ -175,7 +175,7 @@ def test():
 
     c.delete_bucket(bucket, headers=DEVPAY_HEADERS)
 
-    print '--- tests completed ---'
+    print('--- tests completed ---')
 
 if __name__ == '__main__':
     test()

--- a/tests/integration/gs/test_basic.py
+++ b/tests/integration/gs/test_basic.py
@@ -30,9 +30,10 @@ Some integration tests for the GSConnection
 
 import os
 import re
-import StringIO
 import urllib
 import xml.sax
+
+from six import StringIO
 
 from boto import handler
 from boto import storage_uri

--- a/tests/integration/gs/test_generation_conditionals.py
+++ b/tests/integration/gs/test_generation_conditionals.py
@@ -23,10 +23,11 @@
 
 """Integration tests for GS versioning support."""
 
-import StringIO
 import os
 import tempfile
 from xml import sax
+
+from six import StringIO
 
 from boto import handler
 from boto.exception import GSResponseError

--- a/tests/integration/gs/test_resumable_downloads.py
+++ b/tests/integration/gs/test_resumable_downloads.py
@@ -32,7 +32,7 @@ from boto.s3.resumable_download_handler import get_cur_file_size
 from boto.s3.resumable_download_handler import ResumableDownloadHandler
 from boto.exception import ResumableTransferDisposition
 from boto.exception import ResumableDownloadException
-from cb_test_harness import CallbackTestHarness
+from .cb_test_harness import CallbackTestHarness
 from tests.integration.gs.testcase import GSTestCase
 
 

--- a/tests/integration/gs/test_resumable_uploads.py
+++ b/tests/integration/gs/test_resumable_uploads.py
@@ -23,11 +23,12 @@
 Tests of Google Cloud Storage resumable uploads.
 """
 
-import StringIO
 import errno
 import random
 import os
 import time
+
+from six import StringIO
 
 import boto
 from boto import storage_uri
@@ -35,7 +36,7 @@ from boto.gs.resumable_upload_handler import ResumableUploadHandler
 from boto.exception import InvalidUriError
 from boto.exception import ResumableTransferDisposition
 from boto.exception import ResumableUploadException
-from cb_test_harness import CallbackTestHarness
+from .cb_test_harness import CallbackTestHarness
 from tests.integration.gs.testcase import GSTestCase
 
 

--- a/tests/integration/gs/test_storage_uri.py
+++ b/tests/integration/gs/test_storage_uri.py
@@ -25,7 +25,8 @@
 
 import binascii
 import re
-import StringIO
+
+from six import StringIO
 
 from boto import storage_uri
 from boto.exception import BotoClientError

--- a/tests/integration/gs/util.py
+++ b/tests/integration/gs/util.py
@@ -75,7 +75,7 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
                     if logger:
                         logger.warning(msg)
                     else:
-                        print msg
+                        print(msg)
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff

--- a/tests/integration/rds/test_db_subnet_group.py
+++ b/tests/integration/rds/test_db_subnet_group.py
@@ -32,15 +32,15 @@ from boto.rds import RDSConnection
 
 def _is_ok(subnet_group, vpc_id, description, subnets):
     if subnet_group.vpc_id != vpc_id:
-        print 'vpc_id is ',subnet_group.vpc_id, 'but should be ', vpc_id
+        print('vpc_id is ',subnet_group.vpc_id, 'but should be ', vpc_id)
         return 0
     if subnet_group.description != description:
-        print "description is '"+subnet_group.description+"' but should be '"+description+"'"
+        print("description is '"+subnet_group.description+"' but should be '"+description+"'")
         return 0
     if set(subnet_group.subnet_ids) != set(subnets):
         subnets_are = ','.join(subnet_group.subnet_ids)
         should_be   = ','.join(subnets)
-        print "subnets are "+subnets_are+" but should be "+should_be
+        print("subnets are "+subnets_are+" but should be "+should_be)
         return 0
     return 1
 

--- a/tests/integration/rds/test_promote_modify.py
+++ b/tests/integration/rds/test_promote_modify.py
@@ -35,11 +35,11 @@ class PromoteReadReplicaTest(unittest.TestCase):
                     self.conn.delete_dbinstance(db, skip_final_snapshot=True)
 
     def test_promote(self):
-        print '--- running RDS promotion & renaming tests ---'
+        print('--- running RDS promotion & renaming tests ---')
         self.masterDB = self.conn.create_dbinstance(self.masterDB_name, 5, 'db.t1.micro', 'root', 'bototestpw')
         
         # Wait up to 15 minutes for the masterDB to become available
-        print '--- waiting for "%s" to become available  ---' % self.masterDB_name
+        print('--- waiting for "%s" to become available  ---' % self.masterDB_name)
         wait_timeout = time.time() + (15 * 60)
         time.sleep(60)
  
@@ -56,7 +56,7 @@ class PromoteReadReplicaTest(unittest.TestCase):
         self.replicaDB = self.conn.create_dbinstance_read_replica(self.replicaDB_name, self.masterDB_name)
 
         # Wait up to 15 minutes for the replicaDB to become available
-        print '--- waiting for "%s" to become available  ---' % self.replicaDB_name
+        print('--- waiting for "%s" to become available  ---' % self.replicaDB_name)
         wait_timeout = time.time() + (15 * 60)
         time.sleep(60)
         
@@ -74,7 +74,7 @@ class PromoteReadReplicaTest(unittest.TestCase):
         self.replicaDB = self.conn.promote_read_replica(self.replicaDB_name)
 
         # Wait up to 15 minutes for the replicaDB to become available
-        print '--- waiting for "%s" to be promoted and available  ---' % self.replicaDB_name
+        print('--- waiting for "%s" to be promoted and available  ---' % self.replicaDB_name)
         wait_timeout = time.time() + (15 * 60)
         time.sleep(60)
         
@@ -97,12 +97,12 @@ class PromoteReadReplicaTest(unittest.TestCase):
         inst = instances[0]
         self.assertFalse(inst.read_replica_dbinstance_identifiers)
 
-        print '--- renaming "%s" to "%s" ---' % ( self.replicaDB_name, self.renamedDB_name )
+        print('--- renaming "%s" to "%s" ---' % ( self.replicaDB_name, self.renamedDB_name ))
 
         self.renamedDB = self.conn.modify_dbinstance(self.replicaDB_name, new_instance_id=self.renamedDB_name, apply_immediately=True)
 
         # Wait up to 15 minutes for the masterDB to become available
-        print '--- waiting for "%s" to exist  ---' % self.renamedDB_name
+        print('--- waiting for "%s" to exist  ---' % self.renamedDB_name)
 
         wait_timeout = time.time() + (15 * 60)
         time.sleep(60)
@@ -119,7 +119,7 @@ class PromoteReadReplicaTest(unittest.TestCase):
 
         self.assertTrue(found)
 
-        print '--- waiting for "%s" to become available ---' % self.renamedDB_name
+        print('--- waiting for "%s" to become available ---' % self.renamedDB_name)
 
         instances = self.conn.get_all_dbinstances(self.renamedDB_name)
         inst = instances[0]
@@ -135,4 +135,4 @@ class PromoteReadReplicaTest(unittest.TestCase):
         # Since the replica DB was renamed...
         self.replicaDB = None
 
-        print '--- tests completed ---'
+        print('--- tests completed ---')

--- a/tests/integration/s3/test_connection.py
+++ b/tests/integration/s3/test_connection.py
@@ -70,7 +70,7 @@ class S3ConnectionTest (unittest.TestCase):
         url = k.generate_url(3600, force_http=True)
         file = urlopen(url)
         assert s1 == file.read().decode('utf-8'), 'invalid URL %s' % url
-        url = k.generate_url(3600, force_http=True, headers={'x-amz-x-token' : 'XYZ'})
+        url = k.generate_url(3600, force_http=True, headers={'x-amz-x-token': 'XYZ'})
         file = urlopen(url)
         assert s1 == file.read().decode('utf-8'), 'invalid URL %s' % url
         rh = {'response-content-disposition': 'attachment; filename="foo.txt"'}
@@ -88,7 +88,7 @@ class S3ConnectionTest (unittest.TestCase):
         con = http_client.HTTPConnection(up.hostname, up.port)
         con.request("PUT", up.path + '?' + up.query, body="hello there")
         resp = con.getresponse()
-        assert 200 == resp.status
+        self.assertEqual(200, resp.status)
         assert b"hello there" == k.get_contents_as_string()
         bucket.delete_key(k)
         # test a few variations on get_all_keys - first load some data

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -458,7 +458,7 @@ class S3KeyTest(unittest.TestCase):
              "AES256",
             "x-amz-server-side-encryption-customer-key" :
              "MAAxAHQAZQBzAHQASwBlAHkAVABvAFMAUwBFAEMAIQA=",
-            "x-amz-server-side-encryption-customer-key-md5" :
+            "x-amz-server-side-encryption-customer-key-MD5" :
              "fUgCZDDh6bfEMuP2bN38mg==",
         }
         # upload and download content with AWS specified headers
@@ -467,7 +467,6 @@ class S3KeyTest(unittest.TestCase):
         kn = self.bucket.new_key("testkey_for_sse_c")
         ks = kn.get_contents_as_string(headers=header)
         self.assertEqual(ks, content.encode('utf-8'))
-        self.assertFalse(True)
 
 
 class S3KeySigV4Test(unittest.TestCase):

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -426,8 +426,8 @@ class S3KeyTest(unittest.TestCase):
         self.assertIn(remote_metadata['cache-control'],
                       ('public,%20max-age=500', 'public, max-age=500'))
         self.assertEqual(check.get_metadata('test-plus'), 'A plus (+)')
-        self.assertEqual(check.content_disposition, 'filename=Sch%C3%B6ne%20Zeit.txt')
-        self.assertEqual(remote_metadata['content-disposition'], 'filename=Sch%C3%B6ne%20Zeit.txt')
+        self.assertEqual(check.content_disposition, 'filename=Sch%C3%B6ne Zeit.txt')
+        self.assertEqual(remote_metadata['content-disposition'], 'filename=Sch%C3%B6ne Zeit.txt')
         self.assertEqual(check.content_encoding, 'gzip')
         self.assertEqual(remote_metadata['content-encoding'], 'gzip')
         self.assertEqual(check.content_language, 'de')
@@ -436,8 +436,8 @@ class S3KeyTest(unittest.TestCase):
         self.assertEqual(remote_metadata['content-type'], 'application/pdf')
         self.assertEqual(check.x_robots_tag, 'all')
         self.assertEqual(remote_metadata['x-robots-tag'], 'all')
-        self.assertEqual(check.expires, 'Thu,%2001%20Dec%201994%2016:00:00%20GMT')
-        self.assertEqual(remote_metadata['expires'], 'Thu,%2001%20Dec%201994%2016:00:00%20GMT')
+        self.assertEqual(check.expires, 'Thu, 01 Dec 1994 16:00:00 GMT')
+        self.assertEqual(remote_metadata['expires'], 'Thu, 01 Dec 1994 16:00:00 GMT')
 
         expected = u'filename=Schöne Zeit.txt'
         if six.PY2:
@@ -458,8 +458,8 @@ class S3KeyTest(unittest.TestCase):
              "AES256",
             "x-amz-server-side-encryption-customer-key" :
              "MAAxAHQAZQBzAHQASwBlAHkAVABvAFMAUwBFAEMAIQA=",
-            "x-amz-server-side-encryption-customer-key-MD5" :
-             "fUgCZDDh6bfEMuP2bN38mg=="
+            "x-amz-server-side-encryption-customer-key-md5" :
+             "fUgCZDDh6bfEMuP2bN38mg==",
         }
         # upload and download content with AWS specified headers
         k = self.bucket.new_key("testkey_for_sse_c")
@@ -467,6 +467,7 @@ class S3KeyTest(unittest.TestCase):
         kn = self.bucket.new_key("testkey_for_sse_c")
         ks = kn.get_contents_as_string(headers=header)
         self.assertEqual(ks, content.encode('utf-8'))
+        self.assertFalse(True)
 
 
 class S3KeySigV4Test(unittest.TestCase):

--- a/tests/mturk/all_tests.py
+++ b/tests/mturk/all_tests.py
@@ -3,11 +3,11 @@ import unittest
 import doctest
 from glob import glob
 
-from create_hit_test import *
-from create_hit_with_qualifications import *
-from create_hit_external import *
-from create_hit_with_qualifications import *
-from hit_persistence import *
+from .create_hit_test import *
+from .create_hit_with_qualifications import *
+from .create_hit_external import *
+from .create_hit_with_qualifications import *
+from .hit_persistence import *
 
 doctest_suite = doctest.DocFileSuite(
 	*glob('*.doctest'),

--- a/tests/mturk/cleanup_tests.py
+++ b/tests/mturk/cleanup_tests.py
@@ -1,47 +1,47 @@
 import itertools
 
-from _init_environment import SetHostMTurkConnection
-from _init_environment import config_environment
+from ._init_environment import SetHostMTurkConnection
+from ._init_environment import config_environment
 
 def description_filter(substring):
-	return lambda hit: substring in hit.Title
+  return lambda hit: substring in hit.Title
 
 def disable_hit(hit):
-	return conn.disable_hit(hit.HITId)
+  return conn.disable_hit(hit.HITId)
 
 def dispose_hit(hit):
-	# assignments must be first approved or rejected
-	for assignment in conn.get_assignments(hit.HITId):
-		if assignment.AssignmentStatus == 'Submitted':
-			conn.approve_assignment(assignment.AssignmentId)
-	return conn.dispose_hit(hit.HITId)
+  # assignments must be first approved or rejected
+  for assignment in conn.get_assignments(hit.HITId):
+    if assignment.AssignmentStatus == 'Submitted':
+      conn.approve_assignment(assignment.AssignmentId)
+  return conn.dispose_hit(hit.HITId)
 
 def cleanup():
-	"""Remove any boto test related HIT's"""
-        config_environment()
+  """Remove any boto test related HIT's"""
+  config_environment()
 
-	global conn
-	
-	conn = SetHostMTurkConnection()
+  global conn
+
+  conn = SetHostMTurkConnection()
 
 
-	is_boto = description_filter('Boto')
-	print 'getting hits...'
-	all_hits = list(conn.get_all_hits())
-	is_reviewable = lambda hit: hit.HITStatus == 'Reviewable'
-	is_not_reviewable = lambda hit: not is_reviewable(hit)
-	hits_to_process = filter(is_boto, all_hits)
-	hits_to_disable = filter(is_not_reviewable, hits_to_process)
-	hits_to_dispose = filter(is_reviewable, hits_to_process)
-	print 'disabling/disposing %d/%d hits' % (len(hits_to_disable), len(hits_to_dispose))
-	map(disable_hit, hits_to_disable)
-	map(dispose_hit, hits_to_dispose)
+  is_boto = description_filter('Boto')
+  print('getting hits...')
+  all_hits = list(conn.get_all_hits())
+  is_reviewable = lambda hit: hit.HITStatus == 'Reviewable'
+  is_not_reviewable = lambda hit: not is_reviewable(hit)
+  hits_to_process = filter(is_boto, all_hits)
+  hits_to_disable = filter(is_not_reviewable, hits_to_process)
+  hits_to_dispose = filter(is_reviewable, hits_to_process)
+  print('disabling/disposing %d/%d hits' % (len(hits_to_disable), len(hits_to_dispose)))
+  map(disable_hit, hits_to_disable)
+  map(dispose_hit, hits_to_dispose)
 
-	total_hits = len(all_hits)
-	hits_processed = len(hits_to_process)
-	skipped = total_hits - hits_processed
-	fmt = 'Processed: %(total_hits)d HITs, disabled/disposed: %(hits_processed)d, skipped: %(skipped)d'
-	print fmt % vars()
+  total_hits = len(all_hits)
+  hits_processed = len(hits_to_process)
+  skipped = total_hits - hits_processed
+  fmt = 'Processed: %(total_hits)d HITs, disabled/disposed: %(hits_processed)d, skipped: %(skipped)d'
+  print(fmt % vars())
 
 if __name__ == '__main__':
-	cleanup()
+  cleanup()

--- a/tests/mturk/common.py
+++ b/tests/mturk/common.py
@@ -5,7 +5,7 @@ import datetime
 from boto.mturk.question import (
         Question, QuestionContent, AnswerSpecification, FreeTextAnswer,
 )
-from _init_environment import SetHostMTurkConnection, config_environment
+from ._init_environment import SetHostMTurkConnection, config_environment
 
 class MTurkCommon(unittest.TestCase):
         def setUp(self):

--- a/tests/mturk/common.py
+++ b/tests/mturk/common.py
@@ -20,7 +20,8 @@ class MTurkCommon(unittest.TestCase):
                 qn_content.append_field('Text', 'What is a boto no hit type?')
 
                 # create the question specification
-                qn = Question(identifier=str(uuid.uuid4()),
+                qn = Question(
+                        identifier=str(uuid.uuid4()),
                         content=qn_content,
                         answer_spec=AnswerSpecification(FreeTextAnswer()))
                 return qn

--- a/tests/mturk/create_hit_external.py
+++ b/tests/mturk/create_hit_external.py
@@ -3,7 +3,7 @@ import uuid
 import datetime
 from boto.mturk.question import ExternalQuestion
 
-from _init_environment import SetHostMTurkConnection, external_url, \
+from ._init_environment import SetHostMTurkConnection, external_url, \
         config_environment
 
 class Test(unittest.TestCase):

--- a/tests/mturk/create_hit_test.py
+++ b/tests/mturk/create_hit_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from boto.mturk.question import QuestionForm
 
-from common import MTurkCommon
+from .common import MTurkCommon
 
 class TestHITCreation(MTurkCommon):
 	def testCallCreateHitWithOneQuestion(self):

--- a/tests/mturk/create_hit_with_qualifications.py
+++ b/tests/mturk/create_hit_with_qualifications.py
@@ -10,7 +10,7 @@ def test():
     qualifications.add(PercentAssignmentsApprovedRequirement(comparator="GreaterThan", integer_value="95"))
     create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', qualifications=qualifications)
     assert(create_hit_rs.status == True)
-    print create_hit_rs.HITTypeId
+    print(create_hit_rs.HITTypeId)
 
 if __name__ == "__main__":
     test()

--- a/tests/mturk/hit_persistence.py
+++ b/tests/mturk/hit_persistence.py
@@ -1,7 +1,7 @@
 import unittest
 import pickle
 
-from common import MTurkCommon
+from .common import MTurkCommon
 
 class TestHITPersistence(MTurkCommon):
 	def create_hit_result(self):

--- a/tests/mturk/test_disable_hit.py
+++ b/tests/mturk/test_disable_hit.py
@@ -1,6 +1,6 @@
 from tests.mturk.support import unittest
 
-from common import MTurkCommon
+from .common import MTurkCommon
 from boto.mturk.connection import MTurkRequestError
 
 class TestDisableHITs(MTurkCommon):

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -484,7 +484,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             # HTTPResponse objects.
             self.assertEqual(mocked_mexe.call_count, 1)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 self.default_host
             )
 
@@ -502,7 +502,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, error_response)
                 self.assertEqual(mocked_mexe.call_count, 1)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     other_host
                 )
 
@@ -518,7 +518,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             self.assertEqual(cm.exception, error_response)
             self.assertEqual(mocked_mexe.call_count, 1)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 self.default_host
             )
 
@@ -535,7 +535,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             self.assertEqual(cm.exception, error_response)
             self.assertEqual(mocked_mexe.call_count, 1)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 other_host
             )
 
@@ -553,7 +553,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 2)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -572,7 +572,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             self.assertEqual(response, self.success_response)
             self.assertEqual(mocked_mexe.call_count, 2)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 self.default_retried_host
             )
 
@@ -591,7 +591,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             self.assertEqual(response, self.success_response)
             self.assertEqual(mocked_mexe.call_count, 2)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 'a.s3.a.s3.us-east-2.amazonaws.com'
             )
 
@@ -610,7 +610,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
             self.assertEqual(response, self.success_response)
             self.assertEqual(mocked_mexe.call_count, 2)
             self.assertEqual(
-                mocked_mexe.call_args.args[0].host,
+                mocked_mexe.call_args[0][0].host,
                 self.default_retried_host
             )
 
@@ -628,7 +628,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 2)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -646,7 +646,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 2)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -665,7 +665,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 3)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -684,7 +684,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 3)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -703,7 +703,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, self.success_response)
                 self.assertEqual(mocked_mexe.call_count, 3)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_retried_host
                 )
 
@@ -722,7 +722,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(response, error_response)
                 self.assertEqual(mocked_mexe.call_count, 2)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_host
                 )
 
@@ -742,7 +742,7 @@ class TestMakeRequestRetriesWithCorrectHost(AWSMockServiceTestCase):
                 self.assertEqual(cm.exception, error_response)
                 self.assertEqual(mocked_mexe.call_count, 2)
                 self.assertEqual(
-                    mocked_mexe.call_args.args[0].host,
+                    mocked_mexe.call_args[0][0].host,
                     self.default_host
                 )
 


### PR DESCRIPTION
A lot of S3 related tests have been breaking. I tried to fix as many as possible. 

But I am not able to fix a couple of them.
Specifically:
```
integration/s3/test_key.py:S3KeyTest.test_set_contents_with_sse_c
integration/s3/test_connection.py:S3ConnectionTest.test_1_basic
```
At least the first one is breaking because of the V4 signature change. For the second one, it is probably the same reason.

I have been testing using this command:
```
cd tests
python3 test.py -t s3 integration/s3/test_key.py:S3KeyTest.test_set_contents_with_sse_c
```

Followed the instructions here to tests http://boto.cloudhackers.com/en/latest/contributing.html#running-the-tests