### PR TITLE
Fix proxy connection for gcs

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -833,10 +833,14 @@ class AWSAuthConnection(object):
             boto.log.debug(msg)
             key_file = self.http_connection_kwargs.get('key_file', None)
             cert_file = self.http_connection_kwargs.get('cert_file', None)
-            sslSock = ssl.wrap_socket(sock, keyfile=key_file,
-                                      certfile=cert_file,
-                                      cert_reqs=ssl.CERT_REQUIRED,
-                                      ca_certs=self.ca_certificates_file)
+
+            context = ssl.create_default_context()
+            context.verify_mode = ssl.CERT_REQUIRED
+            context.check_hostname = True
+            if cert_file:
+              context.load_cert_chain(cert_file, key_file)
+            context.load_verify_locations(self.ca_certificates_file)
+            sslSock = context.wrap_socket(sock, server_hostname=self.host)
             cert = sslSock.getpeercert()
             hostname = self.host.split(':', 0)[0]
             if not https_connection.ValidateCertificateHostname(cert, hostname):

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -178,23 +178,38 @@ class TestAWSAuthConnection(unittest.TestCase):
 
     @mock.patch.object(socket, 'create_connection')
     @mock.patch('boto.compat.http_client.HTTPResponse')
-    @mock.patch('boto.compat.http_client.ssl')
-    def test_proxy_ssl(self, ssl_mock, http_response_mock,
-                       create_connection_mock):
-        type(http_response_mock.return_value).status = mock.PropertyMock(
-            return_value=200)
+    @mock.patch('boto.connection.ssl', autospec=True)
+    def test_proxy_ssl_with_verification(self, ssl_mock,
+        http_response_mock,
+        create_connection_mock):
+      type(http_response_mock.return_value).status = mock.PropertyMock(
+          return_value=200)
 
-        conn = AWSAuthConnection(
-            'mockservice.cc-zone-1.amazonaws.com',
-            aws_access_key_id='access_key',
-            aws_secret_access_key='secret',
-            suppress_consec_slashes=False,
-            proxy_port=80
-        )
-        conn.https_validate_certificates = False
+      conn = AWSAuthConnection(
+          'mockservice.s3.amazonaws.com',
+          aws_access_key_id='access_key',
+          aws_secret_access_key='secret',
+          suppress_consec_slashes=False,
+          proxy_port=80
+      )
+      conn.https_validate_certificates = True
+      dummy_cert = {
+          'subjectAltName': (('DNS', 's3.amazonaws.com'), ('DNS', '*.s3.amazonaws.com')),
+      }
+      mock_sock = mock.Mock()
+      create_connection_mock.return_value = mock_sock
+      mock_sslSock = mock.Mock()
+      mock_sslSock.getpeercert.return_value = dummy_cert
+      mock_context = mock.Mock()
+      mock_context.wrap_socket.return_value = mock_sslSock
+      ssl_mock.create_default_context.return_value = mock_context
 
-        # Attempt to call proxy_ssl and make sure it works
-        conn.proxy_ssl('mockservice.cc-zone-1.amazonaws.com', 80)
+      # Attempt to call proxy_ssl and make sure it works
+      conn.proxy_ssl('mockservice.s3.amazonaws.com', 80)
+      mock_sslSock.getpeercert.assert_called_once_with()
+      mock_context.wrap_socket.assert_called_once_with(
+          mock_sock,
+          server_hostname='mockservice.s3.amazonaws.com')
 
     # this tests the proper setting of the host_header in v4 signing
     def test_host_header_with_nonstandard_port(self):

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -194,7 +194,8 @@ class TestAWSAuthConnection(unittest.TestCase):
       )
       conn.https_validate_certificates = True
       dummy_cert = {
-          'subjectAltName': (('DNS', 's3.amazonaws.com'), ('DNS', '*.s3.amazonaws.com')),
+          'subjectAltName': (('DNS', 's3.amazonaws.com'),
+                             ('DNS', '*.s3.amazonaws.com')),
       }
       mock_sock = mock.Mock()
       create_connection_mock.return_value = mock_sock


### PR DESCRIPTION
Accessing GCS endpoint via a proxy using the boto library throws `SSL Verification failed` error.

ssl.wrap_socket is deprecated as per https://docs.python.org/3/library/ssl.html#socket-creation
Using the context.wrap_socket instead. This workflow is used by httplib2 as well https://github.com/httplib2/httplib2/blob/9bf300cdc372938f4237150d5b9b615879eb51a1/python3/httplib2/__init__.py#L1326

Modified the test case to also check the http_verification.

A lot of existing tests are failing. I have a separate PR for that so that this change does not get cluttered with non relevant changes https://github.com/gsutil-mirrors/boto/pull/13


The proxy behavior was tested using a squid-proxy on a VM.