### PR TITLE
Add payload logging for list buckets

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -446,6 +446,7 @@ class S3Connection(AWSAuthConnection):
     def get_all_buckets(self, headers=None):
         response = self.make_request('GET', headers=headers)
         body = response.read()
+        boto.log.debug(body)
         if response.status > 300:
             raise self.provider.storage_response_error(
                 response.status, response.reason, body)


### PR DESCRIPTION
This is similar to how list objects payloads are logged: https://github.com/gsutil-mirrors/boto/blob/develop/boto/s3/bucket.py#L405