### PR TITLE
Fix alphabetization in canonical header strings.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -421,7 +421,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
                 c_value = ' '.join(raw_value.strip().split())
             normalized_headers[c_name] = c_value
         
-        for key in sorted(normalized_headers.keys()):
+        for key in sorted(normalized_headers):
             canonical.append('%s:%s' % (key, normalized_headers[key]))
         return '\n'.join(canonical)
 

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -411,6 +411,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         """
         canonical = []
 
+        normalized_headers = {}
         for header in headers_to_sign:
             c_name = header.lower().strip()
             raw_value = str(headers_to_sign[header])
@@ -418,8 +419,11 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
                 c_value = raw_value.strip()
             else:
                 c_value = ' '.join(raw_value.strip().split())
-            canonical.append('%s:%s' % (c_name, c_value))
-        return '\n'.join(sorted(canonical))
+            normalized_headers[c_name] = c_value
+        
+        for key in sorted(normalized_headers.keys()):
+            canonical.append('%s:%s' % (key, normalized_headers[key]))
+        return '\n'.join(canonical)
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in headers_to_sign]

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -507,6 +507,9 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
 
     def test_non_string_headers(self):
         self.awesome_bucket_request.headers['Content-Length'] = 8
+        # Ensures headers are alphabetized, not 'header:value' strings:
+        self.awesome_bucket_request.headers['x-amz-server-side-encryption-customer-key-md5'] = 2
+        self.awesome_bucket_request.headers['x-amz-server-side-encryption-customer-key'] = 1
         canonical_headers = self.auth.canonical_headers(
             self.awesome_bucket_request.headers)
         self.assertEqual(
@@ -515,7 +518,9 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
             'user-agent:Boto\n'
             'x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae'
             '41e4649b934ca495991b7852b855\n'
-            'x-amz-date:20130605T193245Z'
+            'x-amz-date:20130605T193245Z\n'
+            'x-amz-server-side-encryption-customer-key:1\n'
+            'x-amz-server-side-encryption-customer-key-md5:2'
         )
 
 

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -507,7 +507,9 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
 
     def test_non_string_headers(self):
         self.awesome_bucket_request.headers['Content-Length'] = 8
-        # Ensures headers are alphabetized, not 'header:value' strings:
+        # Headers in canonical order are alphabetized by key alone.
+        # This test ensures we are not alphabetizing based on the header/value
+        # separator as well:
         self.awesome_bucket_request.headers['x-amz-server-side-encryption-customer-key-md5'] = 2
         self.awesome_bucket_request.headers['x-amz-server-side-encryption-customer-key'] = 1
         canonical_headers = self.auth.canonical_headers(


### PR DESCRIPTION
Tested with `nose tests/unit/auth/test_sigv4.py`