### PR TITLE
Py 3.12 Changes

### DIFF
--- a/bin/cwutil
+++ b/bin/cwutil
@@ -7,7 +7,7 @@
 import boto
 cw = boto.connect_cloudwatch()
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 def _parse_time(time_string):
     """Internal function to parse a time string"""
@@ -52,11 +52,11 @@ def stats(namespace, metric_name, dimensions=None, statistics="Average", start_t
     if end_time:
         end_time = _parse_time(end_time)
     else:
-        end_time = datetime.utcnow()
+        end_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     if start_time:
         start_time = _parse_time(start_time)
     else:
-        start_time = datetime.utcnow() - timedelta(days=1)
+        start_time = datetime.now(tz=timezone.utc).replace(tzinfo=None) - timedelta(days=1)
             
     print "%-30s %s" % ('Timestamp', statistics)
     print "-"*50

--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -1136,7 +1136,7 @@ def storage_uri(uri_str, default_scheme='file', debug=0, validate=True,
     * gs://bucket
     * s3://bucket
     * filename (which could be a Unix path like /a/b/c or a Windows path like
-      C:\a\b\c)
+      C:\a\b\\c)
 
     The last example uses the default scheme ('file', unless overridden).
     """

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -547,7 +547,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         # authorization header is removed first.
         if 'X-Amzn-Authorization' in req.headers:
             del req.headers['X-Amzn-Authorization']
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         req.headers['X-Amz-Date'] = now.strftime('%Y%m%dT%H%M%SZ')
         if self._provider.security_token:
             req.headers['X-Amz-Security-Token'] = self._provider.security_token
@@ -777,7 +777,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
         """
         if iso_date is None:
-            iso_date = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+            iso_date = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None).strftime('%Y%m%dT%H%M%SZ')
 
         region = self.determine_region_name(req.host)
         service = self.determine_service_name(req.host)

--- a/boto/cloudfront/distribution.py
+++ b/boto/cloudfront/distribution.py
@@ -540,7 +540,7 @@ class Distribution(object):
         :type policy_url: str
         :param policy_url: If provided, allows the signature to contain
             wildcard globs in the URL.  For example, you could
-            provide: 'http://example.com/media/\*' and the policy
+            provide: 'http://example.com/media/*' and the policy
             and signature would allow access to all contents of
             the media subdirectory. If not specified, only
             allow access to the exact url provided in 'url'.

--- a/boto/cloudsearchdomain/layer1.py
+++ b/boto/cloudsearchdomain/layer1.py
@@ -270,7 +270,7 @@ class CloudSearchDomainConnection(AWSAuthConnection):
               ~ operator to perform a sloppy phrase search. Disabling the `fuzzy`
               operator disables the ability to use the ~ operator to perform a
               fuzzy search. `escape` disables the ability to use a backslash (
-              `\`) to escape special characters within the search string.
+              `\\`) to escape special characters within the search string.
               Disabling whitespace is an advanced option that prevents the parser
               from tokenizing on whitespace, which can be useful for Vietnamese.
               (It prevents Vietnamese words from being split incorrectly.) For

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -668,10 +668,10 @@ class AWSAuthConnection(object):
         self.proxy_pass = proxy_pass
         if 'http_proxy' in os.environ and not self.proxy:
             pattern = re.compile(
-                '(?:http://)?'
-                '(?:(?P<user>[\w\-\.]+):(?P<pass>.*)@)?'
-                '(?P<host>[\w\-\.]+)'
-                '(?::(?P<port>\d+))?'
+                r'(?:http://)?'
+                r'(?:(?P<user>[\w\-\.]+):(?P<pass>.*)@)?'
+                r'(?P<host>[\w\-\.]+)'
+                r'(?::(?P<port>\d+))?'
             )
             match = pattern.match(os.environ['http_proxy'])
             if match:
@@ -1117,8 +1117,8 @@ class AWSAuthConnection(object):
             return self._fix_s3_endpoint_region(request.host, err.region)
         elif err.error_code == 'IllegalLocationConstraintException':
             region_regex = (
-                'The (.*?) location constraint is incompatible for the region '
-                'specific endpoint this request was sent to\.'
+                r'The (.*?) location constraint is incompatible for the region '
+                r'specific endpoint this request was sent to\.'
             )
             match = re.search(region_regex, err.body)
             if match and match.group(1) != 'unspecified':

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -29,6 +29,7 @@ import base64
 import warnings
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import boto
 from boto.auth import detect_potential_sigv4
@@ -2600,7 +2601,7 @@ class EC2Connection(AWSQueryConnection):
         # target time (we delete a snapshot if there's another snapshot
         # that was made closer to the preceding target time).
 
-        now = datetime.utcnow()
+        now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         last_hour = datetime(now.year, now.month, now.day, now.hour)
         last_midnight = datetime(now.year, now.month, now.day)
         last_sunday = datetime(now.year, now.month, now.day) - timedelta(days=(now.weekday() + 1) % 7)

--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -237,7 +237,7 @@ class ResumableUploadHandler(object):
         range_spec = resp.getheader('range')
         if range_spec:
             # Parse 'bytes=<from>-<to>' range_spec.
-            m = re.search('bytes=(\d+)-(\d+)', range_spec)
+            m = re.search(r'bytes=(\d+)-(\d+)', range_spec)
             if m:
                 server_start = long(m.group(1))
                 server_end = long(m.group(2))

--- a/boto/https_connection.py
+++ b/boto/https_connection.py
@@ -77,7 +77,7 @@ def ValidateCertificateHostname(cert, hostname):
         "validating server certificate: hostname=%s, certificate hosts=%s",
         hostname, hosts)
     for host in hosts:
-        host_re = host.replace('.', '\.').replace('*', '[^.]*')
+        host_re = host.replace(r'.', r'\.').replace(r'*', r'[^.]*')
         if re.search('^%s$' % (host_re,), hostname, re.I):
             return True
     return False

--- a/boto/manage/task.py
+++ b/boto/manage/task.py
@@ -63,7 +63,7 @@ class Task(Model):
         super(Task, self).__init__(id, **kw)
         self.hourly = self.hour == '*'
         self.daily = self.hour != '*'
-        self.now = datetime.datetime.utcnow()
+        self.now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
 
     def check(self):
         """

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -919,7 +919,7 @@ class HIT(BaseAutoResultElement):
         """ Has this HIT expired yet? """
         expired = False
         if hasattr(self, 'Expiration'):
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
             expiration = datetime.datetime.strptime(self.Expiration, '%Y-%m-%dT%H:%M:%SZ')
             expired = (now >= expiration)
         else:

--- a/boto/opsworks/layer1.py
+++ b/boto/opsworks/layer1.py
@@ -2657,7 +2657,7 @@ class OpsWorksConnection(AWSQueryConnection):
             OpsWorksand by Chef. The short name is also used as the name for
             the directory where your app files are installed. It can have a
             maximum of 200 characters and must be in the following format:
-            /\A[a-z0-9\-\_\.]+\Z/.
+            /\\A[a-z0-9\\-\\_\\.]+\\Z/.
 
         :type attributes: map
         :param attributes: One or more user-defined key/value pairs to be added

--- a/boto/provider.py
+++ b/boto/provider.py
@@ -29,6 +29,7 @@ This class encapsulates the provider-specific header differences.
 import os
 from boto.compat import six
 from datetime import datetime
+from datetime import timezone
 
 import boto
 from boto import config
@@ -253,7 +254,7 @@ class Provider(object):
         else:
             # The credentials should be refreshed if they're going to expire
             # in less than 5 minutes.
-            delta = self._credential_expiry_time - datetime.utcnow()
+            delta = self._credential_expiry_time - datetime.now(tz=timezone.utc).replace(tzinfo=None)
             # python2.6 does not have timedelta.total_seconds() so we have
             # to calculate this ourselves.  This is straight from the
             # datetime docs.

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -95,7 +95,7 @@ class Config(object):
     def load_from_path(self, path):
         file = open(path)
         for line in file.readlines():
-            match = re.match("^#import[\s\t]*([^\s^\t]*)[\s\t]*$", line)
+            match = re.match(r"^#import[\s\t]*([^\s^\t]*)[\s\t]*$", line)
             if match:
                 extended_file = match.group(1)
                 (dir, file) = os.path.split(path)

--- a/boto/redshift/layer1.py
+++ b/boto/redshift/layer1.py
@@ -417,7 +417,7 @@ class RedshiftConnection(AWSQueryConnection):
         + Must contain at least one lowercase letter.
         + Must contain one number.
         + Can be any printable ASCII character (ASCII code 33 to 126) except '
-              (single quote), " (double quote), \, /, @, or space.
+              (single quote), " (double quote), \\, /, @, or space.
 
         :type cluster_security_groups: list
         :param cluster_security_groups: A list of security groups to be
@@ -2189,7 +2189,7 @@ class RedshiftConnection(AWSQueryConnection):
 
         + Cannot exceed 512 characters
         + Cannot contain spaces( ), double quotes ("), single quotes ('), a
-              backslash (\), or control characters. The hexadecimal codes for
+              backslash (\\), or control characters. The hexadecimal codes for
               invalid characters are:
 
             + x00 to x20
@@ -2363,7 +2363,7 @@ class RedshiftConnection(AWSQueryConnection):
         + Must contain at least one lowercase letter.
         + Must contain one number.
         + Can be any printable ASCII character (ASCII code 33 to 126) except '
-              (single quote), " (double quote), \, /, @, or space.
+              (single quote), " (double quote), \\, /, @, or space.
 
         :type cluster_parameter_group_name: string
         :param cluster_parameter_group_name: The name of the cluster parameter

--- a/boto/sdb/db/manager/sdbmanager.py
+++ b/boto/sdb/db/manager/sdbmanager.py
@@ -345,7 +345,7 @@ class SDBConverter(object):
             key = bucket.new_key(str(uuid.uuid4()))
             value.id = "s3://%s/%s" % (key.bucket.name, key.name)
         else:
-            match = re.match("^s3:\/\/([^\/]*)\/(.*)$", value.id)
+            match = re.match(r"^s3://([^/]*)/(.*)$", value.id)
             if match:
                 s3 = self.manager.get_s3_connection()
                 bucket = s3.get_bucket(match.group(1), validate=False)
@@ -360,7 +360,7 @@ class SDBConverter(object):
     def decode_blob(self, value):
         if not value:
             return None
-        match = re.match("^s3:\/\/([^\/]*)\/(.*)$", value)
+        match = re.match(r"^s3://([^/]*)/(.*)$", value)
         if match:
             s3 = self.manager.get_s3_connection()
             bucket = s3.get_bucket(match.group(1), validate=False)

--- a/boto/sdb/db/property.py
+++ b/boto/sdb/db/property.py
@@ -262,7 +262,7 @@ class S3KeyProperty(Property):
 
     data_type = boto.s3.key.Key
     type_name = 'S3Key'
-    validate_regex = "^s3:\/\/([^\/]*)\/(.*)$"
+    validate_regex = r"^s3://([^/]*)/(.*)$"
 
     def __init__(self, verbose_name=None, name=None, default=None,
                  required=False, validator=None, choices=None, unique=False):
@@ -421,7 +421,7 @@ class DateTimeProperty(Property):
         return super(DateTimeProperty, self).get_value_for_datastore(model_instance)
 
     def now(self):
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
 
 
 class DateProperty(Property):

--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -115,7 +115,7 @@ class STSConnection(AWSQueryConnection):
     def _check_token_cache(self, token_key, duration=None, window_seconds=60):
         token = _session_token_cache.get(token_key, None)
         if token:
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
             expires = boto.utils.parse_ts(token.expiration)
             delta = expires - now
             if delta < datetime.timedelta(seconds=window_seconds):

--- a/boto/sts/credentials.py
+++ b/boto/sts/credentials.py
@@ -132,7 +132,7 @@ class Credentials(object):
         :param time_offset_seconds: The number of seconds into the future
             to test the Session Token for expiration.
         """
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         if time_offset_seconds:
             now = now + datetime.timedelta(seconds=time_offset_seconds)
         ts = boto.utils.parse_ts(self.expiration)

--- a/docs/source/cloudsearch_tut.rst
+++ b/docs/source/cloudsearch_tut.rst
@@ -423,10 +423,11 @@ It is also possible to delete documents::
 
     >>> import time
     >>> from datetime import datetime
+    >>> from datetime import timezone
 
     >>> doc_service = domain.get_document_service()
 
     >>> # Again we'll cheat and use the current epoch time as our version number
 
-    >>> doc_service.delete(4, int(time.mktime(datetime.utcnow().timetuple())))
+    >>> doc_service.delete(4, int(time.mktime(datetime.now(tz=timezone.utc).replace(tzinfo=None).timetuple())))
     >>> doc_service.commit()

--- a/docs/source/cloudwatch_tut.rst
+++ b/docs/source/cloudwatch_tut.rst
@@ -79,7 +79,7 @@ that we are interested in.  For this example, let's say we want the
 data for the previous hour::
 
     >>> import datetime
-    >>> end = datetime.datetime.utcnow()
+    >>> end = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
     >>> start = end - datetime.timedelta(hours=1)
 
 We also need to supply the Statistic that we want reported and

--- a/tests/db/test_password.py
+++ b/tests/db/test_password.py
@@ -81,8 +81,8 @@ class PasswordPropertyTest(unittest.TestCase):
         id= obj.id
         time.sleep(5)
         obj = MyModel.get_by_id(id)
-        self.assertEquals(obj.password, 'bar')
-        self.assertEquals(str(obj.password), expected)
+        self.assertEqual(obj.password, 'bar')
+        self.assertEqual(str(obj.password), expected)
                           #hmac.new('mysecret','bar').hexdigest())
  
         
@@ -90,11 +90,11 @@ class PasswordPropertyTest(unittest.TestCase):
         cls = self.test_model()
         obj = cls(id='passwordtest')
         obj.password = 'foo'
-        self.assertEquals('foo', obj.password)
+        self.assertEqual('foo', obj.password)
         obj.save()
         time.sleep(5)
         obj = cls.get_by_id('passwordtest')
-        self.assertEquals('foo', obj.password)
+        self.assertEqual('foo', obj.password)
 
     def test_password_constructor_hashfunc(self):
         import hmac
@@ -103,8 +103,8 @@ class PasswordPropertyTest(unittest.TestCase):
         obj = cls()
         obj.password='hello'
         expected = myhashfunc('hello').hexdigest()
-        self.assertEquals(obj.password, 'hello')
-        self.assertEquals(str(obj.password), expected)
+        self.assertEqual(obj.password, 'hello')
+        self.assertEqual(str(obj.password), expected)
         obj.save()
         id = obj.id
         time.sleep(5)

--- a/tests/integration/cloudformation/test_connection.py
+++ b/tests/integration/cloudformation/test_connection.py
@@ -136,7 +136,7 @@ class TestCloudformationConnection(unittest.TestCase):
         self.assertEqual(self.stack_name, stack.stack_name)
         
         params = [(p.key, p.value) for p in stack.parameters]
-        self.assertEquals([('Parameter1', 'initial_value'),
+        self.assertEqual([('Parameter1', 'initial_value'),
                            ('Parameter2', 'initial_value')], params)
         
         for _ in range(30):
@@ -154,7 +154,7 @@ class TestCloudformationConnection(unittest.TestCase):
         stacks = self.connection.describe_stacks(self.stack_name)
         stack = stacks[0]
         params = [(p.key, p.value) for p in stacks[0].parameters]
-        self.assertEquals([('Parameter1', 'initial_value'),
+        self.assertEqual([('Parameter1', 'initial_value'),
                            ('Parameter2', 'updated_value')], params)
 
         # Waiting for the update to complete to unblock the delete_stack in the

--- a/tests/integration/ec2/cloudwatch/test_connection.py
+++ b/tests/integration/ec2/cloudwatch/test_connection.py
@@ -220,14 +220,14 @@ class CloudWatchConnectionTest(unittest.TestCase):
     def test_get_metric_statistics(self):
         c = CloudWatchConnection()
         m = c.list_metrics()[0]
-        end = datetime.datetime.utcnow()
+        end = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         start = end - datetime.timedelta(hours=24 * 14)
         c.get_metric_statistics(
             3600 * 24, start, end, m.name, m.namespace, ['Average', 'Sum'])
 
     def test_put_metric_data(self):
         c = CloudWatchConnection()
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
         name, namespace = 'unit-test-metric', 'boto-unit-test'
         c.put_metric_data(namespace, name, 5, now, 'Bytes')
 
@@ -240,7 +240,7 @@ class CloudWatchConnectionTest(unittest.TestCase):
         # time.sleep(60)
         # l = metric.query(
         #     now - datetime.timedelta(seconds=60),
-        #     datetime.datetime.utcnow(),
+        #     datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None),
         #     'Average')
         # assert l
         # for row in l:
@@ -261,13 +261,13 @@ class CloudWatchConnectionTest(unittest.TestCase):
 
         c.make_request = make_request
         alarms = c.describe_alarms()
-        self.assertEquals(alarms.next_token, 'mynexttoken')
-        self.assertEquals(alarms[0].name, 'FancyAlarm')
-        self.assertEquals(alarms[0].comparison, '<')
-        self.assertEquals(alarms[0].dimensions, {u'Job': [u'ANiceCronJob']})
-        self.assertEquals(alarms[1].name, 'SuperFancyAlarm')
-        self.assertEquals(alarms[1].comparison, '>')
-        self.assertEquals(alarms[1].dimensions, {u'Job': [u'ABadCronJob']})
+        self.assertEqual(alarms.next_token, 'mynexttoken')
+        self.assertEqual(alarms[0].name, 'FancyAlarm')
+        self.assertEqual(alarms[0].comparison, '<')
+        self.assertEqual(alarms[0].dimensions, {u'Job': [u'ANiceCronJob']})
+        self.assertEqual(alarms[1].name, 'SuperFancyAlarm')
+        self.assertEqual(alarms[1].comparison, '>')
+        self.assertEqual(alarms[1].dimensions, {u'Job': [u'ABadCronJob']})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/gs/test_basic.py
+++ b/tests/integration/gs/test_basic.py
@@ -85,17 +85,17 @@ BILLING_ENABLED = {'BillingConfiguration': {'RequesterPays': 'Enabled'}}
 BILLING_DISABLED = {'BillingConfiguration': {'RequesterPays': 'Disabled'}}
 
 # Regexp for matching project-private default object ACL.
-PROJECT_PRIVATE_RE = ('\s*<AccessControlList>\s*<Entries>\s*<Entry>'
-  '\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
-  '\s*(<Name>[^<]+</Name>)?\s*</Scope>'
-  '\s*<Permission>FULL_CONTROL</Permission>\s*</Entry>\s*<Entry>'
-  '\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
-  '\s*(<Name>[^<]+</Name>)?\s*</Scope>'
-  '\s*<Permission>FULL_CONTROL</Permission>\s*</Entry>\s*<Entry>'
-  '\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
-  '\s*(<Name>[^<]+</Name>)?\s*</Scope>'
-  '\s*<Permission>READ</Permission>\s*</Entry>\s*</Entries>'
-  '\s*</AccessControlList>\s*')
+PROJECT_PRIVATE_RE = (r'\s*<AccessControlList>\s*<Entries>\s*<Entry>'
+  r'\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
+  r'\s*(<Name>[^<]+</Name>)?\s*</Scope>'
+  r'\s*<Permission>FULL_CONTROL</Permission>\s*</Entry>\s*<Entry>'
+  r'\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
+  r'\s*(<Name>[^<]+</Name>)?\s*</Scope>'
+  r'\s*<Permission>FULL_CONTROL</Permission>\s*</Entry>\s*<Entry>'
+  r'\s*<Scope type="GroupById">\s*<ID>[-a-zA-Z0-9]+</ID>'
+  r'\s*(<Name>[^<]+</Name>)?\s*</Scope>'
+  r'\s*<Permission>READ</Permission>\s*</Entry>\s*</Entries>'
+  r'\s*</AccessControlList>\s*')
 
 
 class GSBasicTest(GSTestCase):

--- a/tests/integration/gs/test_generation_conditionals.py
+++ b/tests/integration/gs/test_generation_conditionals.py
@@ -46,7 +46,7 @@ class GSGenerationConditionalsTest(GSTestCase):
         k = b.new_key("foo")
         s1 = "test1"
         fp = StringIO.StringIO(s1)
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_file(fp, if_generation=999)
 
         fp = StringIO.StringIO(s1)
@@ -55,7 +55,7 @@ class GSGenerationConditionalsTest(GSTestCase):
 
         s2 = "test2"
         fp = StringIO.StringIO(s2)
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_file(fp, if_generation=int(g1)+1)
 
         fp = StringIO.StringIO(s2)
@@ -66,14 +66,14 @@ class GSGenerationConditionalsTest(GSTestCase):
         b = self._MakeBucket()
         k = b.new_key("foo")
         s1 = "test1"
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_string(s1, if_generation=999)
 
         k.set_contents_from_string(s1, if_generation=0)
         g1 = k.generation
 
         s2 = "test2"
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_string(s2, if_generation=int(g1)+1)
 
         k.set_contents_from_string(s2, if_generation=g1)
@@ -95,13 +95,13 @@ class GSGenerationConditionalsTest(GSTestCase):
             b = self._MakeBucket()
             k = b.new_key("foo")
 
-            with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+            with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
                 k.set_contents_from_filename(fname1, if_generation=999)
 
             k.set_contents_from_filename(fname1, if_generation=0)
             g1 = k.generation
 
-            with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+            with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
                 k.set_contents_from_filename(fname2, if_generation=int(g1)+1)
 
             k.set_contents_from_filename(fname2, if_generation=g1)
@@ -128,17 +128,17 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             b.set_acl("bucket-owner-full-control", key_name="foo",
                       if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_acl("bucket-owner-full-control", key_name="foo",
                       if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_acl("bucket-owner-full-control", key_name="foo",
                       if_generation=g2, if_metageneration=int(mg2) + 1)
 
@@ -158,7 +158,7 @@ class GSGenerationConditionalsTest(GSTestCase):
         k = b.new_key("foo")
         s1 = "test1"
         fp = StringIO.StringIO(s1)
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_stream(fp, if_generation=999)
 
         fp = StringIO.StringIO(s1)
@@ -168,7 +168,7 @@ class GSGenerationConditionalsTest(GSTestCase):
         k = b.get_key("foo")
         s2 = "test2"
         fp = StringIO.StringIO(s2)
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_stream(fp, if_generation=int(g1)+1)
 
         fp = StringIO.StringIO(s2)
@@ -193,17 +193,17 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             b.set_canned_acl("bucket-owner-full-control", key_name="foo",
                       if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_canned_acl("bucket-owner-full-control", key_name="foo",
                       if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_canned_acl("bucket-owner-full-control", key_name="foo",
                       if_generation=g2, if_metageneration=int(mg2) + 1)
 
@@ -247,15 +247,15 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             b.set_xml_acl(acl, key_name="foo", if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_xml_acl(acl, key_name="foo", if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             b.set_xml_acl(acl, key_name="foo", if_generation=g2,
                           if_metageneration=int(mg2) + 1)
 
@@ -287,15 +287,15 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             k.set_acl("bucket-owner-full-control", if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_acl("bucket-owner-full-control", if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_acl("bucket-owner-full-control", if_generation=g2,
                       if_metageneration=int(mg2) + 1)
 
@@ -326,17 +326,17 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             k.set_canned_acl("bucket-owner-full-control",
                              if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_canned_acl("bucket-owner-full-control",
                              if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_canned_acl("bucket-owner-full-control", if_generation=g2,
                       if_metageneration=int(mg2) + 1)
 
@@ -378,15 +378,15 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(g2, g1)
         self.assertGreater(mg2, mg1)
 
-        with self.assertRaisesRegexp(ValueError, ("Received if_metageneration "
+        with self.assertRaisesRegex(ValueError, ("Received if_metageneration "
                                                   "argument with no "
                                                   "if_generation argument")):
             k.set_xml_acl(acl, if_metageneration=123)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_xml_acl(acl, if_generation=int(g2) + 1)
 
-        with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
+        with self.assertRaisesRegex(GSResponseError, VERSION_MISMATCH):
             k.set_xml_acl(acl, if_generation=g2, if_metageneration=int(mg2) + 1)
 
         k.set_xml_acl(acl, if_generation=g2)

--- a/tests/integration/gs/test_resumable_downloads.py
+++ b/tests/integration/gs/test_resumable_downloads.py
@@ -111,7 +111,7 @@ class ResumableDownloadTests(GSTestCase):
             self.assertTrue(os.path.exists(tracker_file_name))
             f = open(tracker_file_name)
             etag_line = f.readline()
-            self.assertEquals(etag_line.rstrip('\n'), small_src_key.etag.strip('"\''))
+            self.assertEqual(etag_line.rstrip('\n'), small_src_key.etag.strip('"\''))
 
     def test_retryable_exception_recovery(self):
         """

--- a/tests/integration/gs/test_storage_uri.py
+++ b/tests/integration/gs/test_storage_uri.py
@@ -63,7 +63,7 @@ class GSStorageUriTest(GSTestCase):
 
         uri = orig_uri.clone_replace_key(k)
         self.assertTrue(uri.has_version())
-        self.assertRegexpMatches(str(uri.generation), r"[0-9]+")
+        self.assertRegex(str(uri.generation), r"[0-9]+")
 
     def testSetAclXml(self):
         """Ensures that calls to the set_xml_acl functions succeed."""
@@ -98,9 +98,9 @@ class GSStorageUriTest(GSTestCase):
         new_obj_acl_string = k.get_acl().to_xml()
         new_bucket_acl_string = bucket_uri.get_acl().to_xml()
         new_bucket_def_acl_string = bucket_uri.get_def_acl().to_xml()
-        self.assertRegexpMatches(new_obj_acl_string, r"AllUsers")
-        self.assertRegexpMatches(new_bucket_acl_string, r"AllUsers")
-        self.assertRegexpMatches(new_bucket_def_acl_string, r"AllUsers")
+        self.assertRegex(new_obj_acl_string, r"AllUsers")
+        self.assertRegex(new_bucket_acl_string, r"AllUsers")
+        self.assertRegex(new_bucket_def_acl_string, r"AllUsers")
 
     def testPropertiesUpdated(self):
         b = self._MakeBucket()
@@ -108,24 +108,24 @@ class GSStorageUriTest(GSTestCase):
         key_uri = bucket_uri.clone_replace_name("obj")
         key_uri.set_contents_from_string("data1")
 
-        self.assertRegexpMatches(str(key_uri.generation), r"[0-9]+")
+        self.assertRegex(str(key_uri.generation), r"[0-9]+")
         k = b.get_key("obj")
         self.assertEqual(k.generation, key_uri.generation)
-        self.assertEquals(k.get_contents_as_string(), "data1")
+        self.assertEqual(k.get_contents_as_string(), "data1")
 
         key_uri.set_contents_from_stream(StringIO.StringIO("data2"))
-        self.assertRegexpMatches(str(key_uri.generation), r"[0-9]+")
+        self.assertRegex(str(key_uri.generation), r"[0-9]+")
         self.assertGreater(key_uri.generation, k.generation)
         k = b.get_key("obj")
         self.assertEqual(k.generation, key_uri.generation)
-        self.assertEquals(k.get_contents_as_string(), "data2")
+        self.assertEqual(k.get_contents_as_string(), "data2")
 
         key_uri.set_contents_from_file(StringIO.StringIO("data3"))
-        self.assertRegexpMatches(str(key_uri.generation), r"[0-9]+")
+        self.assertRegex(str(key_uri.generation), r"[0-9]+")
         self.assertGreater(key_uri.generation, k.generation)
         k = b.get_key("obj")
         self.assertEqual(k.generation, key_uri.generation)
-        self.assertEquals(k.get_contents_as_string(), "data3")
+        self.assertEqual(k.get_contents_as_string(), "data3")
 
     def testCompose(self):
         data1 = 'hello '
@@ -143,13 +143,13 @@ class GSStorageUriTest(GSTestCase):
         key_uri_composite = bucket_uri.clone_replace_name("composite")
         components = [key_uri1, key_uri2]
         key_uri_composite.compose(components, content_type='text/plain')
-        self.assertEquals(key_uri_composite.get_contents_as_string(),
+        self.assertEqual(key_uri_composite.get_contents_as_string(),
                           data1 + data2)
         composite_key = key_uri_composite.get_key()
         cloud_crc32c = binascii.hexlify(
             composite_key.cloud_hashes['crc32c'])
-        self.assertEquals(cloud_crc32c, hex(expected_crc)[2:])
-        self.assertEquals(composite_key.content_type, 'text/plain')
+        self.assertEqual(cloud_crc32c, hex(expected_crc)[2:])
+        self.assertEqual(composite_key.content_type, 'text/plain')
 
         # Compose disallowed between buckets.
         key_uri1.bucket_name += '2'
@@ -157,6 +157,6 @@ class GSStorageUriTest(GSTestCase):
             key_uri_composite.compose(components)
             self.fail('Composing between buckets didn\'t fail as expected.')
         except BotoClientError as err:
-            self.assertEquals(
+            self.assertEqual(
                 err.reason, 'GCS does not support inter-bucket composing')
 

--- a/tests/integration/gs/test_versioning.py
+++ b/tests/integration/gs/test_versioning.py
@@ -257,11 +257,11 @@ class GSVersioningTest(GSTestCase):
         self.assertIsNone(k.generation)
         k.set_contents_from_string("test1")
         g1 = k.generation
-        self.assertRegexpMatches(g1, r'[0-9]+')
+        self.assertRegex(g1, r'[0-9]+')
         self.assertEqual(k.metageneration, '1')
         k.set_contents_from_string("test2")
         g2 = k.generation
         self.assertNotEqual(g1, g2)
-        self.assertRegexpMatches(g2, r'[0-9]+')
+        self.assertRegex(g2, r'[0-9]+')
         self.assertGreater(int(g2), int(g1))
         self.assertEqual(k.metageneration, '1')

--- a/tests/integration/route53/test_health_check.py
+++ b/tests/integration/route53/test_health_check.py
@@ -31,22 +31,22 @@ class TestRoute53HealthCheck(Route53TestCase):
     def test_create_health_check(self):
         hc = HealthCheck(ip_addr="54.217.7.118", port=80, hc_type="HTTP", resource_path="/testing")
         result = self.conn.create_health_check(hc)
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTP')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTP')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'IPAddress'], '54.217.7.118')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'ResourcePath'], '/testing')
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
 
     def test_create_https_health_check(self):
         hc = HealthCheck(ip_addr="54.217.7.118", port=443, hc_type="HTTPS", resource_path="/testing")
         result = self.conn.create_health_check(hc)
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'IPAddress'], '54.217.7.118')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '443')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '443')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'ResourcePath'], '/testing')
         self.assertFalse('FullyQualifiedDomainName' in result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'])
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
@@ -54,11 +54,11 @@ class TestRoute53HealthCheck(Route53TestCase):
     def test_create_https_health_check_fqdn(self):
         hc = HealthCheck(ip_addr=None, port=443, hc_type="HTTPS", resource_path="/", fqdn="google.com")
         result = self.conn.create_health_check(hc)
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'FullyQualifiedDomainName'], 'google.com')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '443')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '443')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'ResourcePath'], '/')
         self.assertFalse('IPAddress' in result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'])
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
@@ -92,25 +92,25 @@ class TestRoute53HealthCheck(Route53TestCase):
     def test_create_health_check_string_match(self):
         hc = HealthCheck(ip_addr="54.217.7.118", port=80, hc_type="HTTP_STR_MATCH", resource_path="/testing", string_match="test")
         result = self.conn.create_health_check(hc)
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTP_STR_MATCH')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTP_STR_MATCH')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'IPAddress'], '54.217.7.118')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'ResourcePath'], '/testing')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'SearchString'], 'test')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'SearchString'], 'test')
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
 
     def test_create_health_check_https_string_match(self):
         hc = HealthCheck(ip_addr="54.217.7.118", port=80, hc_type="HTTPS_STR_MATCH", resource_path="/testing", string_match="test")
         result = self.conn.create_health_check(hc)
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS_STR_MATCH')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Type'], 'HTTPS_STR_MATCH')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'IPAddress'], '54.217.7.118')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'Port'], '80')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][
                           u'HealthCheck'][u'HealthCheckConfig'][u'ResourcePath'], '/testing')
-        self.assertEquals(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'SearchString'], 'test')
+        self.assertEqual(result[u'CreateHealthCheckResponse'][u'HealthCheck'][u'HealthCheckConfig'][u'SearchString'], 'test')
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
 
     def test_create_resource_record_set(self):
@@ -150,7 +150,7 @@ class TestRoute53HealthCheck(Route53TestCase):
         result = self.conn.create_health_check(hc)
         hc_config = (result[u'CreateHealthCheckResponse']
                      [u'HealthCheck'][u'HealthCheckConfig'])
-        self.assertEquals(hc_config[u'RequestInterval'],
+        self.assertEqual(hc_config[u'RequestInterval'],
                           six.text_type(hc_params['request_interval']))
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
 
@@ -160,7 +160,7 @@ class TestRoute53HealthCheck(Route53TestCase):
         result = self.conn.create_health_check(hc)
         hc_config = (result[u'CreateHealthCheckResponse']
                      [u'HealthCheck'][u'HealthCheckConfig'])
-        self.assertEquals(hc_config[u'FailureThreshold'],
+        self.assertEqual(hc_config[u'FailureThreshold'],
                           six.text_type(hc_params['failure_threshold']))
         self.conn.delete_health_check(result['CreateHealthCheckResponse']['HealthCheck']['Id'])
 

--- a/tests/integration/route53/test_zone.py
+++ b/tests/integration/route53/test_zone.py
@@ -47,14 +47,14 @@ class TestRoute53Zone(unittest.TestCase):
     def test_a(self):
         self.zone.add_a(self.base_domain, '102.11.23.1', 80)
         record = self.zone.get_a(self.base_domain)
-        self.assertEquals(record.name, u'%s.' % self.base_domain)
-        self.assertEquals(record.resource_records, [u'102.11.23.1'])
-        self.assertEquals(record.ttl, u'80')
+        self.assertEqual(record.name, u'%s.' % self.base_domain)
+        self.assertEqual(record.resource_records, [u'102.11.23.1'])
+        self.assertEqual(record.ttl, u'80')
         self.zone.update_a(self.base_domain, '186.143.32.2', '800')
         record = self.zone.get_a(self.base_domain)
-        self.assertEquals(record.name, u'%s.' % self.base_domain)
-        self.assertEquals(record.resource_records, [u'186.143.32.2'])
-        self.assertEquals(record.ttl, u'800')
+        self.assertEqual(record.name, u'%s.' % self.base_domain)
+        self.assertEqual(record.resource_records, [u'186.143.32.2'])
+        self.assertEqual(record.ttl, u'800')
 
     def test_cname(self):
         self.zone.add_cname(
@@ -63,22 +63,22 @@ class TestRoute53Zone(unittest.TestCase):
             200
         )
         record = self.zone.get_cname('www.%s' % self.base_domain)
-        self.assertEquals(record.name, u'www.%s.' % self.base_domain)
-        self.assertEquals(record.resource_records, [
+        self.assertEqual(record.name, u'www.%s.' % self.base_domain)
+        self.assertEqual(record.resource_records, [
             u'webserver.%s.' % self.base_domain
         ])
-        self.assertEquals(record.ttl, u'200')
+        self.assertEqual(record.ttl, u'200')
         self.zone.update_cname(
             'www.%s' % self.base_domain,
             'web.%s' % self.base_domain,
             45
         )
         record = self.zone.get_cname('www.%s' % self.base_domain)
-        self.assertEquals(record.name, u'www.%s.' % self.base_domain)
-        self.assertEquals(record.resource_records, [
+        self.assertEqual(record.name, u'www.%s.' % self.base_domain)
+        self.assertEqual(record.resource_records, [
             u'web.%s.' % self.base_domain
         ])
-        self.assertEquals(record.ttl, u'45')
+        self.assertEqual(record.ttl, u'45')
 
     def test_mx(self):
         self.zone.add_mx(
@@ -90,10 +90,10 @@ class TestRoute53Zone(unittest.TestCase):
             1000
         )
         record = self.zone.get_mx(self.base_domain)
-        self.assertEquals(set(record.resource_records),
+        self.assertEqual(set(record.resource_records),
                           set([u'10 mx1.%s.' % self.base_domain,
                                u'20 mx2.%s.' % self.base_domain]))
-        self.assertEquals(record.ttl, u'1000')
+        self.assertEqual(record.ttl, u'1000')
         self.zone.update_mx(
             self.base_domain,
             [
@@ -103,10 +103,10 @@ class TestRoute53Zone(unittest.TestCase):
             50
         )
         record = self.zone.get_mx(self.base_domain)
-        self.assertEquals(set(record.resource_records),
+        self.assertEqual(set(record.resource_records),
                           set([u'10 mail1.%s.' % self.base_domain,
                                '20 mail2.%s.' % self.base_domain]))
-        self.assertEquals(record.ttl, u'50')
+        self.assertEqual(record.ttl, u'50')
 
     def test_get_records(self):
         self.zone.get_records()
@@ -128,7 +128,7 @@ class TestRoute53Zone(unittest.TestCase):
             'A',
             all=True
         )
-        self.assertEquals(len(wrrs), 2)
+        self.assertEqual(len(wrrs), 2)
         self.zone.delete_a('wrr.%s' % self.base_domain, all=True)
 
     def test_identifiers_lbrs(self):
@@ -141,7 +141,7 @@ class TestRoute53Zone(unittest.TestCase):
             'A',
             all=True
         )
-        self.assertEquals(len(lbrs), 2)
+        self.assertEqual(len(lbrs), 2)
         self.zone.delete_a('lbr.%s' % self.base_domain,
                            identifier=('bam', 'us-west-1'))
         self.zone.delete_a('lbr.%s' % self.base_domain,

--- a/tests/integration/s3/test_connect_to_region.py
+++ b/tests/integration/s3/test_connect_to_region.py
@@ -37,41 +37,41 @@ class S3SpecifyHost(unittest.TestCase):
     def testWithNonAWSHost(self):
         connect_args = dict({'host':'www.not-a-website.com'})
         connection = connect_to_region('us-east-1', **connect_args)
-        self.assertEquals('www.not-a-website.com', connection.host)
+        self.assertEqual('www.not-a-website.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def testSuccessWithHostOverrideRegion(self):
         connect_args = dict({'host':'s3.amazonaws.com'})
         connection = connect_to_region('us-west-2', **connect_args)
-        self.assertEquals('s3.amazonaws.com', connection.host)
+        self.assertEqual('s3.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
 
     def testSuccessWithDefaultUSWest1(self):
         connection = connect_to_region('us-west-2')
-        self.assertEquals('s3-us-west-2.amazonaws.com', connection.host)
+        self.assertEqual('s3-us-west-2.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def testSuccessWithDefaultUSEast1(self):
         connection = connect_to_region('us-east-1')
-        self.assertEquals('s3.amazonaws.com', connection.host)
+        self.assertEqual('s3.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def testSuccessWithDefaultEUCentral1(self):
         connection = connect_to_region('eu-central-1')
-        self.assertEquals('s3.eu-central-1.amazonaws.com', connection.host)
+        self.assertEqual('s3.eu-central-1.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def testDefaultWithInvalidHost(self):
         connect_args = dict({'host':''})
         connection = connect_to_region('us-west-2', **connect_args)
-        self.assertEquals('s3-us-west-2.amazonaws.com', connection.host)
+        self.assertEqual('s3-us-west-2.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def testDefaultWithInvalidHostNone(self):
         connect_args = dict({'host':None})
         connection = connect_to_region('us-east-1', **connect_args)
-        self.assertEquals('s3.amazonaws.com', connection.host)
+        self.assertEqual('s3.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
     def tearDown(self):

--- a/tests/mturk/create_free_text_question_regex.doctest
+++ b/tests/mturk/create_free_text_question_regex.doctest
@@ -63,7 +63,7 @@ u'2'
 u'3600'
 
 # expiration should be very close to now + the lifetime in seconds
->>> expected_datetime = datetime.datetime.utcnow() + datetime.timedelta(seconds=3900)
+>>> expected_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None) + datetime.timedelta(seconds=3900)
 >>> expiration_datetime = datetime.datetime.strptime(hit.Expiration, '%Y-%m-%dT%H:%M:%SZ')
 >>> delta = expected_datetime - expiration_datetime
 >>> abs(delta).seconds < 5

--- a/tests/mturk/create_hit.doctest
+++ b/tests/mturk/create_hit.doctest
@@ -55,7 +55,7 @@ u'2'
 u'3600'
 
 # expiration should be very close to now + the lifetime
->>> expected_datetime = datetime.datetime.utcnow() + lifetime
+>>> expected_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None) + lifetime
 >>> expiration_datetime = datetime.datetime.strptime(hit.Expiration, '%Y-%m-%dT%H:%M:%SZ')
 >>> delta = expected_datetime - expiration_datetime
 >>> abs(delta).seconds < 5

--- a/tests/mturk/create_hit_binary.doctest
+++ b/tests/mturk/create_hit_binary.doctest
@@ -57,7 +57,7 @@ u'2'
 u'3600'
 
 # expiration should be very close to now + the lifetime
->>> expected_datetime = datetime.datetime.utcnow() + lifetime
+>>> expected_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None) + lifetime
 >>> expiration_datetime = datetime.datetime.strptime(hit.Expiration, '%Y-%m-%dT%H:%M:%SZ')
 >>> delta = expected_datetime - expiration_datetime
 >>> abs(delta).seconds < 5

--- a/tests/mturk/create_hit_from_hit_type.doctest
+++ b/tests/mturk/create_hit_from_hit_type.doctest
@@ -65,7 +65,7 @@ u'2'
 u'3600'
 
 # expiration should be very close to now + the lifetime in seconds
->>> expected_datetime = datetime.datetime.utcnow() + datetime.timedelta(seconds=3900)
+>>> expected_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None) + datetime.timedelta(seconds=3900)
 >>> expiration_datetime = datetime.datetime.strptime(hit.Expiration, '%Y-%m-%dT%H:%M:%SZ')
 >>> delta = expected_datetime - expiration_datetime
 >>> abs(delta).seconds < 5

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -104,7 +104,7 @@ class TestCloudFormationCreateStack(CloudFormationConnectionBase):
     def test_create_stack_fails(self):
         self.set_http_response(status_code=400, reason='Bad Request',
             body=b'{"Error": {"Code": 1, "Message": "Invalid arg."}}')
-        with self.assertRaisesRegexp(self.service_connection.ResponseError,
+        with self.assertRaisesRegex(self.service_connection.ResponseError,
             'Invalid arg.'):
             api_response = self.service_connection.create_stack(
                 'stack_name', template_body=SAMPLE_TEMPLATE,

--- a/tests/unit/cloudsearch/test_exceptions.py
+++ b/tests/unit/cloudsearch/test_exceptions.py
@@ -24,7 +24,7 @@ class CloudSearchJSONExceptionTest(CloudSearchSearchBaseTest):
         with mock.patch.object(json, 'loads', fake_loads_value_error):
             search = SearchConnection(endpoint=HOSTNAME)
 
-            with self.assertRaisesRegexp(SearchServiceException, 'non-json'):
+            with self.assertRaisesRegex(SearchServiceException, 'non-json'):
                 search.search(q='test')
 
     @unittest.skipUnless(hasattr(json, 'JSONDecodeError'),
@@ -33,5 +33,5 @@ class CloudSearchJSONExceptionTest(CloudSearchSearchBaseTest):
         with mock.patch.object(json, 'loads', fake_loads_json_error):
             search = SearchConnection(endpoint=HOSTNAME)
 
-            with self.assertRaisesRegexp(SearchServiceException, 'non-json'):
+            with self.assertRaisesRegex(SearchServiceException, 'non-json'):
                 search.search(q='test')

--- a/tests/unit/cloudsearch/test_search.py
+++ b/tests/unit/cloudsearch/test_search.py
@@ -384,7 +384,7 @@ class CloudSearchUnauthorizedTest(CloudSearchSearchBaseTest):
     def test_response(self):
         search = SearchConnection(endpoint=HOSTNAME)
 
-        with self.assertRaisesRegexp(SearchServiceException, 'foo bar baz'):
+        with self.assertRaisesRegex(SearchServiceException, 'foo bar baz'):
             search.search(q='Test')
 
 

--- a/tests/unit/cloudsearch2/test_document.py
+++ b/tests/unit/cloudsearch2/test_document.py
@@ -343,4 +343,4 @@ class CloudSearchDocumentErrorMismatch(CloudSearchDocumentTest):
         except CommitMismatchError as e:
             self.assertTrue(hasattr(e, 'errors'))
             self.assertIsInstance(e.errors, list)
-            self.assertEquals(e.errors[0], self.response['errors'][0].get('message'))
+            self.assertEqual(e.errors[0], self.response['errors'][0].get('message'))

--- a/tests/unit/cloudsearch2/test_exceptions.py
+++ b/tests/unit/cloudsearch2/test_exceptions.py
@@ -24,7 +24,7 @@ class CloudSearchJSONExceptionTest(CloudSearchSearchBaseTest):
         with mock.patch.object(json, 'loads', fake_loads_value_error):
             search = SearchConnection(endpoint=HOSTNAME)
 
-            with self.assertRaisesRegexp(SearchServiceException, 'non-json'):
+            with self.assertRaisesRegex(SearchServiceException, 'non-json'):
                 search.search(q='test')
 
     @unittest.skipUnless(hasattr(json, 'JSONDecodeError'),
@@ -33,5 +33,5 @@ class CloudSearchJSONExceptionTest(CloudSearchSearchBaseTest):
         with mock.patch.object(json, 'loads', fake_loads_json_error):
             search = SearchConnection(endpoint=HOSTNAME)
 
-            with self.assertRaisesRegexp(SearchServiceException, 'non-json'):
+            with self.assertRaisesRegex(SearchServiceException, 'non-json'):
                 search.search(q='test')

--- a/tests/unit/cloudsearch2/test_search.py
+++ b/tests/unit/cloudsearch2/test_search.py
@@ -330,7 +330,7 @@ class CloudSearchUnauthorizedTest(CloudSearchSearchBaseTest):
     def test_response(self):
         search = SearchConnection(endpoint=HOSTNAME)
 
-        with self.assertRaisesRegexp(SearchServiceException, 'foo bar baz'):
+        with self.assertRaisesRegex(SearchServiceException, 'foo bar baz'):
             search.search(q='Test')
 
 

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -832,33 +832,33 @@ class TestGetAllImages(TestEC2ConnectionBase):
     def test_get_all_images(self):
         self.set_http_response(status_code=200)
         parsed = self.ec2.get_all_images()
-        self.assertEquals(1, len(parsed))
-        self.assertEquals("ami-abcd1234", parsed[0].id)
-        self.assertEquals("111111111111/windows2008r2-hvm-i386-20130702", parsed[0].location)
-        self.assertEquals("available", parsed[0].state)
-        self.assertEquals("111111111111", parsed[0].ownerId)
-        self.assertEquals("111111111111", parsed[0].owner_id)
-        self.assertEquals(False, parsed[0].is_public)
-        self.assertEquals("i386", parsed[0].architecture)
-        self.assertEquals("machine", parsed[0].type)
-        self.assertEquals(None, parsed[0].kernel_id)
-        self.assertEquals(None, parsed[0].ramdisk_id)
-        self.assertEquals(None, parsed[0].owner_alias)
-        self.assertEquals("windows", parsed[0].platform)
-        self.assertEquals("Windows Test", parsed[0].name)
-        self.assertEquals("Windows Test Description", parsed[0].description)
-        self.assertEquals("ebs", parsed[0].root_device_type)
-        self.assertEquals("/dev/sda1", parsed[0].root_device_name)
-        self.assertEquals("hvm", parsed[0].virtualization_type)
-        self.assertEquals("xen", parsed[0].hypervisor)
-        self.assertEquals(None, parsed[0].instance_lifecycle)
+        self.assertEqual(1, len(parsed))
+        self.assertEqual("ami-abcd1234", parsed[0].id)
+        self.assertEqual("111111111111/windows2008r2-hvm-i386-20130702", parsed[0].location)
+        self.assertEqual("available", parsed[0].state)
+        self.assertEqual("111111111111", parsed[0].ownerId)
+        self.assertEqual("111111111111", parsed[0].owner_id)
+        self.assertEqual(False, parsed[0].is_public)
+        self.assertEqual("i386", parsed[0].architecture)
+        self.assertEqual("machine", parsed[0].type)
+        self.assertEqual(None, parsed[0].kernel_id)
+        self.assertEqual(None, parsed[0].ramdisk_id)
+        self.assertEqual(None, parsed[0].owner_alias)
+        self.assertEqual("windows", parsed[0].platform)
+        self.assertEqual("Windows Test", parsed[0].name)
+        self.assertEqual("Windows Test Description", parsed[0].description)
+        self.assertEqual("ebs", parsed[0].root_device_type)
+        self.assertEqual("/dev/sda1", parsed[0].root_device_name)
+        self.assertEqual("hvm", parsed[0].virtualization_type)
+        self.assertEqual("xen", parsed[0].hypervisor)
+        self.assertEqual(None, parsed[0].instance_lifecycle)
 
         # 1 billing product parsed into a list
-        self.assertEquals(1, len(parsed[0].billing_products))
-        self.assertEquals("bp-6ba54002", parsed[0].billing_products[0])
+        self.assertEqual(1, len(parsed[0].billing_products))
+        self.assertEqual("bp-6ba54002", parsed[0].billing_products[0])
 
         # Just verify length, there is already a block_device_mapping test
-        self.assertEquals(5, len(parsed[0].block_device_mapping))
+        self.assertEqual(5, len(parsed[0].block_device_mapping))
 
         # TODO: No tests for product codes?
 
@@ -976,14 +976,14 @@ class TestModifyInterfaceAttribute(TestEC2ConnectionBase):
     def test_modify_group_set_invalid(self):
         self.set_http_response(status_code=200)
 
-        with self.assertRaisesRegexp(TypeError, 'iterable'):
+        with self.assertRaisesRegex(TypeError, 'iterable'):
             self.ec2.modify_network_interface_attribute('id', 'groupSet',
                                                         False)
 
     def test_modify_attr_invalid(self):
         self.set_http_response(status_code=200)
 
-        with self.assertRaisesRegexp(ValueError, 'Unknown attribute'):
+        with self.assertRaisesRegex(ValueError, 'Unknown attribute'):
             self.ec2.modify_network_interface_attribute('id', 'invalid', 0)
 
 

--- a/tests/unit/ec2/test_networkinterface.py
+++ b/tests/unit/ec2/test_networkinterface.py
@@ -53,7 +53,7 @@ class NetworkInterfaceTests(unittest.TestCase):
     def test_update_with_validate_true_raises_value_error(self):
         self.eni_one.connection = mock.Mock()
         self.eni_one.connection.get_all_network_interfaces.return_value = []
-        with self.assertRaisesRegexp(ValueError, "^eni-1 is not a valid ENI ID$"):
+        with self.assertRaisesRegex(ValueError, "^eni-1 is not a valid ENI ID$"):
             self.eni_one.update(True)
 
     def test_update_with_result_set_greater_than_0_updates_dict(self):

--- a/tests/unit/ec2/test_reservedinstance.py
+++ b/tests/unit/ec2/test_reservedinstance.py
@@ -38,7 +38,7 @@ class TestReservedInstancesSet(AWSMockServiceTestCase):
 
         self.assertEqual(len(response), 1)
         self.assertTrue(isinstance(response[0], ReservedInstance))
-        self.assertEquals(response[0].id, 'ididididid')
-        self.assertEquals(response[0].instance_count, 5)
-        self.assertEquals(response[0].start, '2014-05-03T14:10:10.944Z')
-        self.assertEquals(response[0].end, '2014-05-03T14:10:11.000Z')
+        self.assertEqual(response[0].id, 'ididididid')
+        self.assertEqual(response[0].instance_count, 5)
+        self.assertEqual(response[0].start, '2014-05-03T14:10:10.944Z')
+        self.assertEqual(response[0].end, '2014-05-03T14:10:11.000Z')

--- a/tests/unit/ec2/test_volume.py
+++ b/tests/unit/ec2/test_volume.py
@@ -113,7 +113,7 @@ class VolumeTests(unittest.TestCase):
     def test_update_with_validate_true_raises_value_error(self):
         self.volume_one.connection = mock.Mock()
         self.volume_one.connection.get_all_volumes.return_value = []
-        with self.assertRaisesRegexp(ValueError, "^1 is not a valid Volume ID$"):
+        with self.assertRaisesRegex(ValueError, "^1 is not a valid Volume ID$"):
             self.volume_one.update(True)
 
     def test_update_returns_status(self):

--- a/tests/unit/emr/test_emr_responses.py
+++ b/tests/unit/emr/test_emr_responses.py
@@ -346,7 +346,7 @@ class TestEMRResponses(unittest.TestCase):
     def _assert_fields(self, response, **fields):
         for field, expected in fields.items():
             actual = getattr(response, field)
-            self.assertEquals(expected, actual,
+            self.assertEqual(expected, actual,
                               "Field %s: %r != %r" % (field, expected, actual))
 
     def test_JobFlows_example(self):
@@ -383,6 +383,6 @@ class TestEMRResponses(unittest.TestCase):
                             masterinstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
-        self.assertEquals(6, len(jobflow.steps))
-        self.assertEquals(2, len(jobflow.instancegroups))
+        self.assertEqual(6, len(jobflow.steps))
+        self.assertEqual(2, len(jobflow.instancegroups))
 

--- a/tests/unit/emr/test_instance_group_args.py
+++ b/tests/unit/emr/test_instance_group_args.py
@@ -17,7 +17,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init raises ValueError when market==spot and
         bidprice is not specified.
         """
-        with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
+        with self.assertRaisesRegex(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
                           'SPOT', 'master')
 
@@ -35,7 +35,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
                                        'SPOT', 'master', bidprice=Decimal(1.10))
-        self.assertEquals('1.10', instance_group.bidprice[:4])
+        self.assertEqual('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
         """
@@ -43,7 +43,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
                                        'SPOT', 'master', bidprice=1.1)
-        self.assertEquals('1.1', instance_group.bidprice)
+        self.assertEqual('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
         """
@@ -51,7 +51,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
                                        'SPOT', 'master', bidprice='1.1')
-        self.assertEquals('1.1', instance_group.bidprice)
+        self.assertEqual('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/glacier/test_layer2.py
+++ b/tests/unit/glacier/test_layer2.py
@@ -257,8 +257,8 @@ class TestVault(GlacierLayer2Base):
             dict(EXAMPLE_PART_LIST_COMPLETE)) # take a copy
         parts_result = self.vault.list_all_parts(sentinel.upload_id)
         expected = [call('examplevault', sentinel.upload_id)]
-        self.assertEquals(expected, self.mock_layer1.list_parts.call_args_list)
-        self.assertEquals(EXAMPLE_PART_LIST_COMPLETE, parts_result)
+        self.assertEqual(expected, self.mock_layer1.list_parts.call_args_list)
+        self.assertEqual(EXAMPLE_PART_LIST_COMPLETE, parts_result)
 
     def test_list_all_parts_two_pages(self):
         self.mock_layer1.list_parts.side_effect = [
@@ -270,8 +270,8 @@ class TestVault(GlacierLayer2Base):
         expected = [call('examplevault', sentinel.upload_id),
                     call('examplevault', sentinel.upload_id,
                          marker=EXAMPLE_PART_LIST_RESULT_PAGE_1['Marker'])]
-        self.assertEquals(expected, self.mock_layer1.list_parts.call_args_list)
-        self.assertEquals(EXAMPLE_PART_LIST_COMPLETE, parts_result)
+        self.assertEqual(expected, self.mock_layer1.list_parts.call_args_list)
+        self.assertEqual(EXAMPLE_PART_LIST_COMPLETE, parts_result)
 
     @patch('boto.glacier.vault.resume_file_upload')
     def test_resume_archive_from_file(self, mock_resume_file_upload):
@@ -313,7 +313,7 @@ class TestJob(GlacierLayer2Base):
 
 class TestRangeStringParsing(unittest.TestCase):
     def test_simple_range(self):
-        self.assertEquals(
+        self.assertEqual(
             Vault._range_string_to_part_index('0-3', 4), 0)
 
     def test_range_one_too_big(self):
@@ -321,7 +321,7 @@ class TestRangeStringParsing(unittest.TestCase):
         # See: https://forums.aws.amazon.com/thread.jspa?threadID=106866&tstart=0
         # Workaround is to assume that if a (start, end] range appears to be
         # returned then that is what it is.
-        self.assertEquals(
+        self.assertEqual(
             Vault._range_string_to_part_index('0-4', 4), 0)
 
     def test_range_too_big(self):
@@ -334,5 +334,5 @@ class TestRangeStringParsing(unittest.TestCase):
 
     def test_range_end_mismatch(self):
         # End mismatch is OK, since the last part might be short
-        self.assertEquals(
+        self.assertEqual(
             Vault._range_string_to_part_index('0-2', 4), 0)

--- a/tests/unit/glacier/test_response.py
+++ b/tests/unit/glacier/test_response.py
@@ -29,7 +29,7 @@ class TestResponse(AWSMockServiceTestCase):
     def test_204_body_isnt_passed_to_json(self):
         response = self.create_response(status_code=204,header=[('Content-Type','application/json')])
         result = GlacierResponse(response,response.getheaders())
-        self.assertEquals(result.status, response.status)
+        self.assertEqual(result.status, response.status)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/glacier/test_writer.py
+++ b/tests/unit/glacier/test_writer.py
@@ -130,7 +130,7 @@ class TestWriter(unittest.TestCase):
     def test_returns_archive_id(self):
         self.writer.write(b'1')
         self.writer.close()
-        self.assertEquals(sentinel.archive_id, self.writer.get_archive_id())
+        self.assertEqual(sentinel.archive_id, self.writer.get_archive_id())
 
     def test_current_tree_hash(self):
         self.writer.write(b'1234')
@@ -178,7 +178,7 @@ class TestWriter(unittest.TestCase):
         self.assertEqual(final_size, self.writer.current_uploaded_size)
 
     def test_upload_id(self):
-        self.assertEquals(sentinel.upload_id, self.writer.upload_id)
+        self.assertEqual(sentinel.upload_id, self.writer.upload_id)
 
 
 class TestResume(unittest.TestCase):
@@ -226,4 +226,4 @@ class TestResume(unittest.TestCase):
         archive_id = resume_file_upload(
             self.vault, sentinel.upload_id, self.part_size, StringIO('1'), {},
             self.chunk_size)
-        self.assertEquals(sentinel.archive_id, archive_id)
+        self.assertEqual(sentinel.archive_id, archive_id)

--- a/tests/unit/iam/test_connection.py
+++ b/tests/unit/iam/test_connection.py
@@ -332,7 +332,7 @@ class TestGenerateCredentialReport(AWSMockServiceTestCase):
     def test_generate_credential_report(self):
         self.set_http_response(status_code=200)
         response = self.service_connection.generate_credential_report()
-        self.assertEquals(response['generate_credential_report_response']
+        self.assertEqual(response['generate_credential_report_response']
                                   ['generate_credential_report_result']
                                   ['state'], 'COMPLETE')
 
@@ -389,7 +389,7 @@ class TestCreateVirtualMFADevice(AWSMockServiceTestCase):
              'VirtualMFADeviceName': 'ExampleName',
              'Action': 'CreateVirtualMFADevice'},
             ignore_params_values=['Version'])
-        self.assertEquals(response['create_virtual_mfa_device_response']
+        self.assertEqual(response['create_virtual_mfa_device_response']
                                   ['create_virtual_mfa_device_result']
                                   ['virtual_mfa_device']
                                   ['serial_number'], 'arn:aws:iam::123456789012:mfa/ExampleName')
@@ -429,7 +429,7 @@ class TestGetAccountPasswordPolicy(AWSMockServiceTestCase):
                 'Action': 'GetAccountPasswordPolicy',
             },
             ignore_params_values=['Version'])
-        self.assertEquals(response['get_account_password_policy_response']
+        self.assertEqual(response['get_account_password_policy_response']
                           ['get_account_password_policy_result']['password_policy']
                           ['minimum_password_length'], '12')
 

--- a/tests/unit/mturk/test_connection.py
+++ b/tests/unit/mturk/test_connection.py
@@ -23,6 +23,6 @@ class TestMTurkConnection(AWSMockServiceTestCase):
     def test_get_file_upload_url_success(self):
         self.set_http_response(status_code=200, body=GET_FILE_UPLOAD_URL)
         rset = self.service_connection.get_file_upload_url('aid', 'qid')
-        self.assertEquals(len(rset), 1)
-        self.assertEquals(rset[0].FileUploadURL,
+        self.assertEqual(len(rset), 1)
+        self.assertEqual(rset[0].FileUploadURL,
                           'http://s3.amazonaws.com/myawsbucket/puppy.jpg')

--- a/tests/unit/mturk/test_locale_qualification_in.py
+++ b/tests/unit/mturk/test_locale_qualification_in.py
@@ -70,7 +70,7 @@ class TestMTurkPostingWithQualificationsIn(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)
 
     def test_locale_qualification_notin_in(self):
         self.set_http_response(
@@ -130,4 +130,4 @@ class TestMTurkPostingWithQualificationsIn(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)

--- a/tests/unit/mturk/test_locale_qualification_notin.py
+++ b/tests/unit/mturk/test_locale_qualification_notin.py
@@ -70,7 +70,7 @@ class TestMTurkPostingWithQualificationsNotin(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)
 
     def test_locale_qualification_in_notin(self):
         self.set_http_response(
@@ -130,4 +130,4 @@ class TestMTurkPostingWithQualificationsNotin(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)

--- a/tests/unit/mturk/test_qualification_doesnotexist.py
+++ b/tests/unit/mturk/test_qualification_doesnotexist.py
@@ -70,4 +70,4 @@ class TestMTurkPostingWithQualificationsDoesnotexist(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)

--- a/tests/unit/mturk/test_qualification_exists.py
+++ b/tests/unit/mturk/test_qualification_exists.py
@@ -70,4 +70,4 @@ class TestMTurkPostingWithQualificationsExists(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)

--- a/tests/unit/mturk/test_qualification_qualtypewithscore_in.py
+++ b/tests/unit/mturk/test_qualification_qualtypewithscore_in.py
@@ -77,4 +77,4 @@ class TestMTurkPostingWithQualQualtypewithscoreIn(AWSMockServiceTestCase):
                                   'Reward.1.CurrencyCode',
                                   'Keywords',
                                   'Operation'])
-        self.assertEquals(create_hit_rs.status, True)
+        self.assertEqual(create_hit_rs.status, True)

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from tests.compat import mock, unittest
 import os
@@ -371,7 +371,7 @@ class TestProvider(unittest.TestCase):
             p = provider.Provider('aws')
 
     def test_refresh_credentials(self):
-        now = datetime.utcnow()
+        now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         first_expiration = (now + timedelta(seconds=10)).strftime(
             "%Y-%m-%dT%H:%M:%SZ")
         credentials = {

--- a/tests/unit/rds/test_connection.py
+++ b/tests/unit/rds/test_connection.py
@@ -660,9 +660,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-26 23:59:00.01 spid54      Authentication mode is MIXED.
 
-2014-01-26 23:59:00.01 spid54      Logging SQL Server messages in file 'D:\RDSDBDATA\Log\ERROR'.
+2014-01-26 23:59:00.01 spid54      Logging SQL Server messages in file 'D:\\RDSDBDATA\\Log\\ERROR'.
 
-2014-01-26 23:59:00.01 spid54      The service account is 'WORKGROUP\AMAZONA-NUQUUMV$'. This is an informational message; no user action is required.
+2014-01-26 23:59:00.01 spid54      The service account is 'WORKGROUP\\AMAZONA-NUQUUMV$'. This is an informational message; no user action is required.
 
 2014-01-26 23:59:00.01 spid54      The error log has been reinitialized. See the previous log for older entries.
 

--- a/tests/unit/s3/test_lifecycle.py
+++ b/tests/unit/s3/test_lifecycle.py
@@ -90,7 +90,7 @@ class TestS3LifeCycle(AWSMockServiceTestCase):
 
     def test_parse_lifecycle_no_prefix(self):
         rule = self._get_bucket_lifecycle_config()[2]
-        self.assertEquals(rule.prefix, '')
+        self.assertEqual(rule.prefix, '')
 
     def test_parse_lifecycle_enabled(self):
         rule = self._get_bucket_lifecycle_config()[0]
@@ -114,22 +114,22 @@ class TestS3LifeCycle(AWSMockServiceTestCase):
 
     def test_parse_transition_days(self):
         transition = self._get_bucket_lifecycle_config()[0].transition[0]
-        self.assertEquals(transition.days, 30)
+        self.assertEqual(transition.days, 30)
         self.assertIsNone(transition.date)
 
     def test_parse_transition_days_deprecated(self):
         transition = self._get_bucket_lifecycle_config()[0].transition
-        self.assertEquals(transition.days, 30)
+        self.assertEqual(transition.days, 30)
         self.assertIsNone(transition.date)
 
     def test_parse_transition_date(self):
         transition = self._get_bucket_lifecycle_config()[1].transition[0]
-        self.assertEquals(transition.date, '2012-12-31T00:00:000Z')
+        self.assertEqual(transition.date, '2012-12-31T00:00:000Z')
         self.assertIsNone(transition.days)
 
     def test_parse_transition_date_deprecated(self):
         transition = self._get_bucket_lifecycle_config()[1].transition
-        self.assertEquals(transition.date, '2012-12-31T00:00:000Z')
+        self.assertEqual(transition.date, '2012-12-31T00:00:000Z')
         self.assertIsNone(transition.days)
 
     def test_parse_storage_class_standard_ia(self):

--- a/tests/unit/sqs/test_connection.py
+++ b/tests/unit/sqs/test_connection.py
@@ -113,7 +113,7 @@ class SQSAuthParams(AWSMockServiceTestCase):
         self.service_connection.get_queue('my_queue', '599169622985')
 
         assert 'QueueOwnerAWSAccountId' in self.actual_request.params.keys()
-        self.assertEquals(self.actual_request.params['QueueOwnerAWSAccountId'], '599169622985')
+        self.assertEqual(self.actual_request.params['QueueOwnerAWSAccountId'], '599169622985')
 
 class SQSProfileName(MockServiceWithConfigTestCase):
     connection_class = SQSConnection
@@ -140,7 +140,7 @@ class SQSProfileName(MockServiceWithConfigTestCase):
         self.initialize_service_connection()
         self.set_http_response(status_code=200)
 
-        self.assertEquals(self.service_connection.profile_name, self.profile_name)
+        self.assertEqual(self.service_connection.profile_name, self.profile_name)
 
 class SQSMessageAttributesParsing(AWSMockServiceTestCase):
     connection_class = SQSConnection

--- a/tests/unit/sqs/test_message.py
+++ b/tests/unit/sqs/test_message.py
@@ -67,8 +67,8 @@ class TestEncodeMessage(unittest.TestCase):
         with self.assertRaises(SQSDecodeError) as context:
             xml.sax.parseString(body.encode('utf-8'), h)
         message = context.exception.message
-        self.assertEquals(message.id, sample_value)
-        self.assertEquals(message.receipt_handle, sample_value)
+        self.assertEqual(message.id, sample_value)
+        self.assertEqual(message.receipt_handle, sample_value)
 
     @attr(sqs=True)
     def test_encode_bytes_message(self):
@@ -92,20 +92,20 @@ class TestBigMessage(unittest.TestCase):
         msg = BigMessage()
         # Try just a bucket name
         bucket, key = msg._get_bucket_key('s3://foo')
-        self.assertEquals(bucket, 'foo')
-        self.assertEquals(key, None)
+        self.assertEqual(bucket, 'foo')
+        self.assertEqual(key, None)
         # Try just a bucket name with trailing "/"
         bucket, key = msg._get_bucket_key('s3://foo/')
-        self.assertEquals(bucket, 'foo')
-        self.assertEquals(key, None)
+        self.assertEqual(bucket, 'foo')
+        self.assertEqual(key, None)
         # Try a bucket and a key
         bucket, key = msg._get_bucket_key('s3://foo/bar')
-        self.assertEquals(bucket, 'foo')
-        self.assertEquals(key, 'bar')
+        self.assertEqual(bucket, 'foo')
+        self.assertEqual(key, 'bar')
         # Try a bucket and a key with "/"
         bucket, key = msg._get_bucket_key('s3://foo/bar/fie/baz')
-        self.assertEquals(bucket, 'foo')
-        self.assertEquals(key, 'bar/fie/baz')
+        self.assertEqual(bucket, 'foo')
+        self.assertEqual(key, 'bar/fie/baz')
         # Try it with no s3:// prefix
         with self.assertRaises(SQSDecodeError) as context:
             bucket, key = msg._get_bucket_key('foo/bar')

--- a/tests/unit/swf/test_layer1_decisions.py
+++ b/tests/unit/swf/test_layer1_decisions.py
@@ -9,7 +9,7 @@ class TestDecisions(unittest.TestCase):
         self.decisions = boto.swf.layer1_decisions.Layer1Decisions()
 
     def assert_data(self, *data):
-        self.assertEquals(self.decisions._data, list(data))
+        self.assertEqual(self.decisions._data, list(data))
 
     def test_continue_as_new_workflow_execution(self):
         self.decisions.continue_as_new_workflow_execution(

--- a/tests/unit/swf/test_layer2_base.py
+++ b/tests/unit/swf/test_layer2_base.py
@@ -22,10 +22,10 @@ class TestBase(unittest.TestCase):
         )
 
     def test_instantiation(self):
-        self.assertEquals(MOCK_DOMAIN, self.swf_base.domain)
-        self.assertEquals(MOCK_ACCESS_KEY, self.swf_base.aws_access_key_id)
-        self.assertEquals(MOCK_SECRET_KEY,
+        self.assertEqual(MOCK_DOMAIN, self.swf_base.domain)
+        self.assertEqual(MOCK_ACCESS_KEY, self.swf_base.aws_access_key_id)
+        self.assertEqual(MOCK_SECRET_KEY,
                           self.swf_base.aws_secret_access_key)
-        self.assertEquals(MOCK_REGION, self.swf_base.region)
+        self.assertEqual(MOCK_REGION, self.swf_base.region)
         boto.swf.layer2.Layer1.assert_called_with(
             MOCK_ACCESS_KEY, MOCK_SECRET_KEY, region=MOCK_REGION)

--- a/tests/unit/swf/test_layer2_domain.py
+++ b/tests/unit/swf/test_layer2_domain.py
@@ -14,8 +14,8 @@ class TestDomain(unittest.TestCase):
         self.domain.region = 'test-region'
 
     def test_domain_instantiation(self):
-        self.assertEquals('test-domain', self.domain.name)
-        self.assertEquals('My test domain', self.domain.description)
+        self.assertEqual('test-domain', self.domain.name)
+        self.assertEqual('My test domain', self.domain.description)
 
     def test_domain_list_activities(self):
         self.domain._swf.list_activity_types.return_value = {
@@ -44,11 +44,11 @@ class TestDomain(unittest.TestCase):
                           'S3Upload', 'SepiaTransform', 'DoUpdate')
 
         activity_types = self.domain.activities()
-        self.assertEquals(6, len(activity_types))
+        self.assertEqual(6, len(activity_types))
         for activity_type in activity_types:
             self.assertIsInstance(activity_type, ActivityType)
             self.assertTrue(activity_type.name in expected_names)
-            self.assertEquals(self.domain.region, activity_type.region)
+            self.assertEqual(self.domain.region, activity_type.region)
 
     def test_domain_list_workflows(self):
         self.domain._swf.list_workflow_types.return_value = {
@@ -63,14 +63,14 @@ class TestDomain(unittest.TestCase):
         expected_names = ('ProcessFile', 'test_workflow_name') 
         
         workflow_types = self.domain.workflows()
-        self.assertEquals(2, len(workflow_types))
+        self.assertEqual(2, len(workflow_types))
         for workflow_type in workflow_types:
             self.assertIsInstance(workflow_type, WorkflowType)
             self.assertTrue(workflow_type.name in expected_names)
-            self.assertEquals(self.domain.aws_access_key_id, workflow_type.aws_access_key_id)
-            self.assertEquals(self.domain.aws_secret_access_key, workflow_type.aws_secret_access_key)
-            self.assertEquals(self.domain.name, workflow_type.domain)
-            self.assertEquals(self.domain.region, workflow_type.region)
+            self.assertEqual(self.domain.aws_access_key_id, workflow_type.aws_access_key_id)
+            self.assertEqual(self.domain.aws_secret_access_key, workflow_type.aws_secret_access_key)
+            self.assertEqual(self.domain.name, workflow_type.domain)
+            self.assertEqual(self.domain.region, workflow_type.region)
 
     def test_domain_list_executions(self):
         self.domain._swf.list_open_workflow_executions.return_value = {
@@ -104,13 +104,13 @@ class TestDomain(unittest.TestCase):
                                       'version': '1.0'}}]}
 
         executions = self.domain.executions()
-        self.assertEquals(4, len(executions))
+        self.assertEqual(4, len(executions))
         for wf_execution in executions:
             self.assertIsInstance(wf_execution, WorkflowExecution)
-            self.assertEquals(self.domain.aws_access_key_id, wf_execution.aws_access_key_id)
-            self.assertEquals(self.domain.aws_secret_access_key, wf_execution.aws_secret_access_key)
-            self.assertEquals(self.domain.name, wf_execution.domain)
-            self.assertEquals(self.domain.region, wf_execution.region)
+            self.assertEqual(self.domain.aws_access_key_id, wf_execution.aws_access_key_id)
+            self.assertEqual(self.domain.aws_secret_access_key, wf_execution.aws_secret_access_key)
+            self.assertEqual(self.domain.name, wf_execution.domain)
+            self.assertEqual(self.domain.region, wf_execution.region)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/swf/test_layer2_types.py
+++ b/tests/unit/swf/test_layer2_types.py
@@ -38,9 +38,9 @@ class TestTypes(unittest.TestCase):
         execution = wf_type.start(task_list='hello_world')
 
         self.assertIsInstance(execution, WorkflowExecution)
-        self.assertEquals(wf_type.name, execution.name)
-        self.assertEquals(wf_type.version, execution.version)
-        self.assertEquals(run_id, execution.runId)
+        self.assertEqual(wf_type.name, execution.name)
+        self.assertEqual(wf_type.version, execution.version)
+        self.assertEqual(run_id, execution.runId)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -29,7 +29,7 @@ class BaseEndpointResolverTest(unittest.TestCase):
                 {
                     'partition': 'aws',
                     'dnsSuffix': 'amazonaws.com',
-                    'regionRegex': '^(us|eu)\-\w+$',
+                    'regionRegex': r"^(us|eu)-\w+$",
                     'defaults': {
                         'hostname': '{service}.{region}.{dnsSuffix}'
                     },
@@ -92,7 +92,7 @@ class BaseEndpointResolverTest(unittest.TestCase):
                 {
                     'partition': 'foo',
                     'dnsSuffix': 'foo.com',
-                    'regionRegex': '^(foo)\-\w+$',
+                    'regionRegex': r"^(foo)-\w+$",
                     'defaults': {
                         'hostname': '{service}.{region}.{dnsSuffix}',
                         'protocols': ['http'],

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -58,17 +58,17 @@ class TestPassword(unittest.TestCase):
     def clstest(self, cls):
         """Insure that password.__eq__ hashes test value before compare."""
         password = cls('foo')
-        self.assertNotEquals(password, 'foo')
+        self.assertNotEqual(password, 'foo')
 
         password.set('foo')
         hashed = str(password)
-        self.assertEquals(password, 'foo')
-        self.assertEquals(password.str, hashed)
+        self.assertEqual(password, 'foo')
+        self.assertEqual(password.str, hashed)
 
         password = cls(hashed)
-        self.assertNotEquals(password.str, 'foo')
-        self.assertEquals(password, 'foo')
-        self.assertEquals(password.str, hashed)
+        self.assertNotEqual(password.str, 'foo')
+        self.assertEqual(password, 'foo')
+        self.assertEqual(password.str, hashed)
 
     def test_aaa_version_1_9_default_behavior(self):
         self.clstest(Password)
@@ -79,7 +79,7 @@ class TestPassword(unittest.TestCase):
 
         password = SHA224Password()
         password.set('foo')
-        self.assertEquals(hashlib.sha224(b'foo').hexdigest(), str(password))
+        self.assertEqual(hashlib.sha224(b'foo').hexdigest(), str(password))
 
     def test_hmac(self):
         def hmac_hashfunc(cls, msg):
@@ -94,7 +94,7 @@ class TestPassword(unittest.TestCase):
         password = HMACPassword()
         password.set('foo')
 
-        self.assertEquals(str(password),
+        self.assertEqual(str(password),
                           hmac.new(b'mysecretkey', b'foo').hexdigest())
 
     def test_constructor(self):
@@ -102,7 +102,7 @@ class TestPassword(unittest.TestCase):
 
         password = Password(hashfunc=hmac_hashfunc)
         password.set('foo')
-        self.assertEquals(password.str,
+        self.assertEqual(password.str,
                           hmac.new(b'mysecretkey', b'foo').hexdigest())
 
 
@@ -381,37 +381,37 @@ class TestParseHost(unittest.TestCase):
     def test_parses_ipv6_hosts_no_brackets(self):
         host = 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, host)
+        self.assertEqual(result, host)
 
     def test_parses_ipv6_hosts_with_brackets_stripping_them(self):
         host = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
+        self.assertEqual(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
 
     def test_parses_ipv6_hosts_with_brackets_and_port(self):
         host = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]:8080'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
+        self.assertEqual(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
 
     def test_parses_ipv4_hosts(self):
         host = '10.0.1.1'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, host)
+        self.assertEqual(result, host)
 
     def test_parses_ipv4_hosts_with_port(self):
         host = '192.168.168.200:8080'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, '192.168.168.200')
+        self.assertEqual(result, '192.168.168.200')
 
     def test_parses_hostnames_with_port(self):
         host = 'example.org:8080'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, 'example.org')
+        self.assertEqual(result, 'example.org')
 
     def test_parses_hostnames_without_port(self):
         host = 'example.org'
         result = boto.utils.parse_host(host)
-        self.assertEquals(result, host)
+        self.assertEqual(result, host)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/vpc/test_customergateway.py
+++ b/tests/unit/vpc/test_customergateway.py
@@ -43,7 +43,7 @@ class TestDescribeCustomerGateways(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(len(api_response), 1)
+        self.assertEqual(len(api_response), 1)
         self.assertIsInstance(api_response[0], CustomerGateway)
         self.assertEqual(api_response[0].id, 'cgw-b4dc3961')
 
@@ -80,11 +80,11 @@ class TestCreateCustomerGateway(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, CustomerGateway)
-        self.assertEquals(api_response.id, 'cgw-b4dc3961')
-        self.assertEquals(api_response.state, 'pending')
-        self.assertEquals(api_response.type, 'ipsec.1')
-        self.assertEquals(api_response.ip_address, '12.1.2.3')
-        self.assertEquals(api_response.bgp_asn, 65534)
+        self.assertEqual(api_response.id, 'cgw-b4dc3961')
+        self.assertEqual(api_response.state, 'pending')
+        self.assertEqual(api_response.type, 'ipsec.1')
+        self.assertEqual(api_response.ip_address, '12.1.2.3')
+        self.assertEqual(api_response.bgp_asn, 65534)
 
 
 class TestDeleteCustomerGateway(AWSMockServiceTestCase):
@@ -108,7 +108,7 @@ class TestDeleteCustomerGateway(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 if __name__ == '__main__':

--- a/tests/unit/vpc/test_dhcpoptions.py
+++ b/tests/unit/vpc/test_dhcpoptions.py
@@ -59,11 +59,11 @@ class TestDescribeDhcpOptions(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(len(api_response), 1)
+        self.assertEqual(len(api_response), 1)
         self.assertIsInstance(api_response[0], DhcpOptions)
-        self.assertEquals(api_response[0].id, 'dopt-7a8b9c2d')
-        self.assertEquals(api_response[0].options['domain-name'], ['example.com'])
-        self.assertEquals(api_response[0].options['domain-name-servers'], ['10.2.5.1', '10.2.5.2'])
+        self.assertEqual(api_response[0].id, 'dopt-7a8b9c2d')
+        self.assertEqual(api_response[0].options['domain-name'], ['example.com'])
+        self.assertEqual(api_response[0].options['domain-name-servers'], ['10.2.5.1', '10.2.5.2'])
 
 
 class TestCreateDhcpOptions(AWSMockServiceTestCase):
@@ -154,12 +154,12 @@ class TestCreateDhcpOptions(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, DhcpOptions)
-        self.assertEquals(api_response.id, 'dopt-7a8b9c2d')
-        self.assertEquals(api_response.options['domain-name'], ['example.com'])
-        self.assertEquals(api_response.options['domain-name-servers'], ['10.2.5.1', '10.2.5.2'])
-        self.assertEquals(api_response.options['ntp-servers'], ['10.12.12.1', '10.12.12.2'])
-        self.assertEquals(api_response.options['netbios-name-servers'], ['10.20.20.1'])
-        self.assertEquals(api_response.options['netbios-node-type'], ['2'])
+        self.assertEqual(api_response.id, 'dopt-7a8b9c2d')
+        self.assertEqual(api_response.options['domain-name'], ['example.com'])
+        self.assertEqual(api_response.options['domain-name-servers'], ['10.2.5.1', '10.2.5.2'])
+        self.assertEqual(api_response.options['ntp-servers'], ['10.12.12.1', '10.12.12.2'])
+        self.assertEqual(api_response.options['netbios-name-servers'], ['10.20.20.1'])
+        self.assertEqual(api_response.options['netbios-node-type'], ['2'])
 
 
 class TestDeleteDhcpOptions(AWSMockServiceTestCase):
@@ -183,7 +183,7 @@ class TestDeleteDhcpOptions(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestAssociateDhcpOptions(AWSMockServiceTestCase):
@@ -209,7 +209,7 @@ class TestAssociateDhcpOptions(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/vpc/test_internetgateway.py
+++ b/tests/unit/vpc/test_internetgateway.py
@@ -40,7 +40,7 @@ class TestDescribeInternetGateway(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(len(api_response), 1)
+        self.assertEqual(len(api_response), 1)
         self.assertIsInstance(api_response[0], InternetGateway)
         self.assertEqual(api_response[0].id, 'igw-eaad4883EXAMPLE')
 
@@ -94,7 +94,7 @@ class TestDeleteInternetGateway(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestAttachInternetGateway(AWSMockServiceTestCase):
@@ -120,7 +120,7 @@ class TestAttachInternetGateway(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestDetachInternetGateway(AWSMockServiceTestCase):
@@ -146,7 +146,7 @@ class TestDetachInternetGateway(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/vpc/test_routetable.py
+++ b/tests/unit/vpc/test_routetable.py
@@ -88,42 +88,42 @@ class TestDescribeRouteTables(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(len(api_response), 2)
+        self.assertEqual(len(api_response), 2)
         self.assertIsInstance(api_response[0], RouteTable)
-        self.assertEquals(api_response[0].id, 'rtb-13ad487a')
-        self.assertEquals(len(api_response[0].routes), 1)
-        self.assertEquals(api_response[0].routes[0].destination_cidr_block, '10.0.0.0/22')
-        self.assertEquals(api_response[0].routes[0].gateway_id, 'local')
-        self.assertEquals(api_response[0].routes[0].state, 'active')
-        self.assertEquals(api_response[0].routes[0].origin, 'CreateRouteTable')
-        self.assertEquals(len(api_response[0].associations), 1)
-        self.assertEquals(api_response[0].associations[0].id, 'rtbassoc-12ad487b')
-        self.assertEquals(api_response[0].associations[0].route_table_id, 'rtb-13ad487a')
+        self.assertEqual(api_response[0].id, 'rtb-13ad487a')
+        self.assertEqual(len(api_response[0].routes), 1)
+        self.assertEqual(api_response[0].routes[0].destination_cidr_block, '10.0.0.0/22')
+        self.assertEqual(api_response[0].routes[0].gateway_id, 'local')
+        self.assertEqual(api_response[0].routes[0].state, 'active')
+        self.assertEqual(api_response[0].routes[0].origin, 'CreateRouteTable')
+        self.assertEqual(len(api_response[0].associations), 1)
+        self.assertEqual(api_response[0].associations[0].id, 'rtbassoc-12ad487b')
+        self.assertEqual(api_response[0].associations[0].route_table_id, 'rtb-13ad487a')
         self.assertIsNone(api_response[0].associations[0].subnet_id)
-        self.assertEquals(api_response[0].associations[0].main, True)
-        self.assertEquals(api_response[1].id, 'rtb-f9ad4890')
-        self.assertEquals(len(api_response[1].routes), 4)
-        self.assertEquals(api_response[1].routes[0].destination_cidr_block, '10.0.0.0/22')
-        self.assertEquals(api_response[1].routes[0].gateway_id, 'local')
-        self.assertEquals(api_response[1].routes[0].state, 'active')
-        self.assertEquals(api_response[1].routes[0].origin, 'CreateRouteTable')
-        self.assertEquals(api_response[1].routes[1].destination_cidr_block, '0.0.0.0/0')
-        self.assertEquals(api_response[1].routes[1].gateway_id, 'igw-eaad4883')
-        self.assertEquals(api_response[1].routes[1].state, 'active')
-        self.assertEquals(api_response[1].routes[1].origin, 'CreateRoute')
-        self.assertEquals(api_response[1].routes[2].destination_cidr_block, '10.0.0.0/21')
-        self.assertEquals(api_response[1].routes[2].interface_id, 'eni-884ec1d1')
-        self.assertEquals(api_response[1].routes[2].state, 'blackhole')
-        self.assertEquals(api_response[1].routes[2].origin, 'CreateRoute')
-        self.assertEquals(api_response[1].routes[3].destination_cidr_block, '11.0.0.0/22')
-        self.assertEquals(api_response[1].routes[3].vpc_peering_connection_id, 'pcx-efc52b86')
-        self.assertEquals(api_response[1].routes[3].state, 'blackhole')
-        self.assertEquals(api_response[1].routes[3].origin, 'CreateRoute')
-        self.assertEquals(len(api_response[1].associations), 1)
-        self.assertEquals(api_response[1].associations[0].id, 'rtbassoc-faad4893')
-        self.assertEquals(api_response[1].associations[0].route_table_id, 'rtb-f9ad4890')
-        self.assertEquals(api_response[1].associations[0].subnet_id, 'subnet-15ad487c')
-        self.assertEquals(api_response[1].associations[0].main, False)
+        self.assertEqual(api_response[0].associations[0].main, True)
+        self.assertEqual(api_response[1].id, 'rtb-f9ad4890')
+        self.assertEqual(len(api_response[1].routes), 4)
+        self.assertEqual(api_response[1].routes[0].destination_cidr_block, '10.0.0.0/22')
+        self.assertEqual(api_response[1].routes[0].gateway_id, 'local')
+        self.assertEqual(api_response[1].routes[0].state, 'active')
+        self.assertEqual(api_response[1].routes[0].origin, 'CreateRouteTable')
+        self.assertEqual(api_response[1].routes[1].destination_cidr_block, '0.0.0.0/0')
+        self.assertEqual(api_response[1].routes[1].gateway_id, 'igw-eaad4883')
+        self.assertEqual(api_response[1].routes[1].state, 'active')
+        self.assertEqual(api_response[1].routes[1].origin, 'CreateRoute')
+        self.assertEqual(api_response[1].routes[2].destination_cidr_block, '10.0.0.0/21')
+        self.assertEqual(api_response[1].routes[2].interface_id, 'eni-884ec1d1')
+        self.assertEqual(api_response[1].routes[2].state, 'blackhole')
+        self.assertEqual(api_response[1].routes[2].origin, 'CreateRoute')
+        self.assertEqual(api_response[1].routes[3].destination_cidr_block, '11.0.0.0/22')
+        self.assertEqual(api_response[1].routes[3].vpc_peering_connection_id, 'pcx-efc52b86')
+        self.assertEqual(api_response[1].routes[3].state, 'blackhole')
+        self.assertEqual(api_response[1].routes[3].origin, 'CreateRoute')
+        self.assertEqual(len(api_response[1].associations), 1)
+        self.assertEqual(api_response[1].associations[0].id, 'rtbassoc-faad4893')
+        self.assertEqual(api_response[1].associations[0].route_table_id, 'rtb-f9ad4890')
+        self.assertEqual(api_response[1].associations[0].subnet_id, 'subnet-15ad487c')
+        self.assertEqual(api_response[1].associations[0].main, False)
 
 
 class TestAssociateRouteTable(AWSMockServiceTestCase):
@@ -149,7 +149,7 @@ class TestAssociateRouteTable(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, 'rtbassoc-f8ad4891')
+        self.assertEqual(api_response, 'rtbassoc-f8ad4891')
 
 
 class TestDisassociateRouteTable(AWSMockServiceTestCase):
@@ -173,7 +173,7 @@ class TestDisassociateRouteTable(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestCreateRouteTable(AWSMockServiceTestCase):
@@ -210,11 +210,11 @@ class TestCreateRouteTable(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, RouteTable)
-        self.assertEquals(api_response.id, 'rtb-f9ad4890')
-        self.assertEquals(len(api_response.routes), 1)
-        self.assertEquals(api_response.routes[0].destination_cidr_block, '10.0.0.0/22')
-        self.assertEquals(api_response.routes[0].gateway_id, 'local')
-        self.assertEquals(api_response.routes[0].state, 'active')
+        self.assertEqual(api_response.id, 'rtb-f9ad4890')
+        self.assertEqual(len(api_response.routes), 1)
+        self.assertEqual(api_response.routes[0].destination_cidr_block, '10.0.0.0/22')
+        self.assertEqual(api_response.routes[0].gateway_id, 'local')
+        self.assertEqual(api_response.routes[0].state, 'active')
 
 
 class TestDeleteRouteTable(AWSMockServiceTestCase):
@@ -238,7 +238,7 @@ class TestDeleteRouteTable(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestReplaceRouteTableAssociation(AWSMockServiceTestCase):
@@ -264,7 +264,7 @@ class TestReplaceRouteTableAssociation(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_replace_route_table_association_with_assoc(self):
         self.set_http_response(status_code=200)
@@ -277,7 +277,7 @@ class TestReplaceRouteTableAssociation(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, 'rtbassoc-faad4893')
+        self.assertEqual(api_response, 'rtbassoc-faad4893')
 
 
 class TestCreateRoute(AWSMockServiceTestCase):
@@ -304,7 +304,7 @@ class TestCreateRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_create_route_instance(self):
         self.set_http_response(status_code=200)
@@ -318,7 +318,7 @@ class TestCreateRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_create_route_interface(self):
         self.set_http_response(status_code=200)
@@ -332,7 +332,7 @@ class TestCreateRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_create_route_vpc_peering_connection(self):
         self.set_http_response(status_code=200)
@@ -346,7 +346,7 @@ class TestCreateRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestReplaceRoute(AWSMockServiceTestCase):
@@ -373,7 +373,7 @@ class TestReplaceRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_replace_route_instance(self):
         self.set_http_response(status_code=200)
@@ -387,7 +387,7 @@ class TestReplaceRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_replace_route_interface(self):
         self.set_http_response(status_code=200)
@@ -401,7 +401,7 @@ class TestReplaceRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_replace_route_vpc_peering_connection(self):
         self.set_http_response(status_code=200)
@@ -415,7 +415,7 @@ class TestReplaceRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestDeleteRoute(AWSMockServiceTestCase):
@@ -440,7 +440,7 @@ class TestDeleteRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/vpc/test_subnet.py
+++ b/tests/unit/vpc/test_subnet.py
@@ -58,7 +58,7 @@ class TestDescribeSubnets(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(len(api_response), 2)
+        self.assertEqual(len(api_response), 2)
         self.assertIsInstance(api_response[0], Subnet)
         self.assertEqual(api_response[0].id, 'subnet-9d4a7b6c')
         self.assertEqual(api_response[1].id, 'subnet-6e7f829e')
@@ -97,12 +97,12 @@ class TestCreateSubnet(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, Subnet)
-        self.assertEquals(api_response.id, 'subnet-9d4a7b6c')
-        self.assertEquals(api_response.state, 'pending')
-        self.assertEquals(api_response.vpc_id, 'vpc-1a2b3c4d')
-        self.assertEquals(api_response.cidr_block, '10.0.1.0/24')
-        self.assertEquals(api_response.available_ip_address_count, 251)
-        self.assertEquals(api_response.availability_zone, 'us-east-1a')
+        self.assertEqual(api_response.id, 'subnet-9d4a7b6c')
+        self.assertEqual(api_response.state, 'pending')
+        self.assertEqual(api_response.vpc_id, 'vpc-1a2b3c4d')
+        self.assertEqual(api_response.cidr_block, '10.0.1.0/24')
+        self.assertEqual(api_response.available_ip_address_count, 251)
+        self.assertEqual(api_response.availability_zone, 'us-east-1a')
 
 
 class TestDeleteSubnet(AWSMockServiceTestCase):
@@ -126,7 +126,7 @@ class TestDeleteSubnet(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 if __name__ == '__main__':

--- a/tests/unit/vpc/test_vpc.py
+++ b/tests/unit/vpc/test_vpc.py
@@ -70,11 +70,11 @@ class TestCreateVpc(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, VPC)
-        self.assertEquals(api_response.id, 'vpc-1a2b3c4d')
-        self.assertEquals(api_response.state, 'pending')
-        self.assertEquals(api_response.cidr_block, '10.0.0.0/16')
-        self.assertEquals(api_response.dhcp_options_id, 'dopt-1a2b3c4d2')
-        self.assertEquals(api_response.instance_tenancy, 'default')
+        self.assertEqual(api_response.id, 'vpc-1a2b3c4d')
+        self.assertEqual(api_response.state, 'pending')
+        self.assertEqual(api_response.cidr_block, '10.0.0.0/16')
+        self.assertEqual(api_response.dhcp_options_id, 'dopt-1a2b3c4d2')
+        self.assertEqual(api_response.instance_tenancy, 'default')
 
 
 class TestDeleteVpc(AWSMockServiceTestCase):
@@ -98,7 +98,7 @@ class TestDeleteVpc(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestModifyVpcAttribute(AWSMockServiceTestCase):
@@ -124,7 +124,7 @@ class TestModifyVpcAttribute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
     def test_modify_vpc_attribute_dns_hostnames(self):
         self.set_http_response(status_code=200)
@@ -137,7 +137,7 @@ class TestModifyVpcAttribute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestGetAllClassicLinkVpc(AWSMockServiceTestCase):

--- a/tests/unit/vpc/test_vpc_peering_connection.py
+++ b/tests/unit/vpc/test_vpc_peering_connection.py
@@ -157,7 +157,7 @@ class TestDeleteVpcPeeringConnection(AWSMockServiceTestCase):
 
     def test_delete_vpc_peering_connection(self):
         self.set_http_response(status_code=200)
-        self.assertEquals(self.service_connection.delete_vpc_peering_connection('pcx-12345678'), True)
+        self.assertEqual(self.service_connection.delete_vpc_peering_connection('pcx-12345678'), True)
 
 class TestDeleteVpcPeeringConnectionShortForm(unittest.TestCase):
     DESCRIBE_VPC_PEERING_CONNECTIONS= b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -199,14 +199,14 @@ class TestDeleteVpcPeeringConnectionShortForm(unittest.TestCase):
         vpc_conn.make_request = mock.Mock(return_value=mock_response)
         vpc_peering_connections = vpc_conn.get_all_vpc_peering_connections()
 
-        self.assertEquals(1, len(vpc_peering_connections))
+        self.assertEqual(1, len(vpc_peering_connections))
         vpc_peering_connection = vpc_peering_connections[0]
 
         mock_response = mock.Mock()
         mock_response.read.return_value = self.DELETE_VPC_PEERING_CONNECTION
         mock_response.status = 200
         vpc_conn.make_request = mock.Mock(return_value=mock_response)
-        self.assertEquals(True, vpc_peering_connection.delete())
+        self.assertEqual(True, vpc_peering_connection.delete())
 
         self.assertIn('DeleteVpcPeeringConnection', vpc_conn.make_request.call_args_list[0][0])
         self.assertNotIn('DeleteVpc', vpc_conn.make_request.call_args_list[0][0])
@@ -224,7 +224,7 @@ class TestRejectVpcPeeringConnection(AWSMockServiceTestCase):
 
     def test_reject_vpc_peering_connection(self):
         self.set_http_response(status_code=200)
-        self.assertEquals(self.service_connection.reject_vpc_peering_connection('pcx-12345678'), True)
+        self.assertEqual(self.service_connection.reject_vpc_peering_connection('pcx-12345678'), True)
 
 
 class TestAcceptVpcPeeringConnection(AWSMockServiceTestCase):

--- a/tests/unit/vpc/test_vpnconnection.py
+++ b/tests/unit/vpc/test_vpnconnection.py
@@ -170,9 +170,9 @@ class TestCreateVPNConnection(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, VpnConnection)
-        self.assertEquals(api_response.id, 'vpn-83ad48ea')
-        self.assertEquals(api_response.customer_gateway_id, 'cgw-b4dc3961')
-        self.assertEquals(api_response.options.static_routes_only, True)
+        self.assertEqual(api_response.id, 'vpn-83ad48ea')
+        self.assertEqual(api_response.customer_gateway_id, 'cgw-b4dc3961')
+        self.assertEqual(api_response.options.static_routes_only, True)
 
 
 class TestDeleteVPNConnection(AWSMockServiceTestCase):
@@ -196,7 +196,7 @@ class TestDeleteVPNConnection(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestCreateVPNConnectionRoute(AWSMockServiceTestCase):
@@ -222,7 +222,7 @@ class TestCreateVPNConnectionRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 
 class TestDeleteVPNConnectionRoute(AWSMockServiceTestCase):
@@ -248,7 +248,7 @@ class TestDeleteVPNConnectionRoute(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        self.assertEquals(api_response, True)
+        self.assertEqual(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/vpc/test_vpngateway.py
+++ b/tests/unit/vpc/test_vpngateway.py
@@ -83,7 +83,7 @@ class TestCreateVpnGateway(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, VpnGateway)
-        self.assertEquals(api_response.id, 'vgw-8db04f81')
+        self.assertEqual(api_response.id, 'vgw-8db04f81')
 
 
 class TestDeleteVpnGateway(AWSMockServiceTestCase):
@@ -136,8 +136,8 @@ class TestAttachVpnGateway(AWSMockServiceTestCase):
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
         self.assertIsInstance(api_response, Attachment)
-        self.assertEquals(api_response.vpc_id, 'vpc-1a2b3c4d')
-        self.assertEquals(api_response.state, 'attaching')
+        self.assertEqual(api_response.vpc_id, 'vpc-1a2b3c4d')
+        self.assertEqual(api_response.state, 'attaching')
 
 
 class TestDetachVpnGateway(AWSMockServiceTestCase):


### PR DESCRIPTION
Added Support for python 3.12

python 3.12 documentation reference: [documentation](https://docs.python.org/dev/whatsnew/3.12.html)

Changes:

- Invalid escape sequence - A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning).
- datetime.utcnow() change - [datetime](https://docs.python.org/dev/library/datetime.html#module-datetime): [datetime.datetime](https://docs.python.org/dev/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [now()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.now) and [fromtimestamp()](https://docs.python.org/dev/library/datetime.html#datetime.datetime.fromtimestamp) with the tz parameter set to [datetime.UTC](https://docs.python.org/dev/library/datetime.html#datetime.UTC). (Contributed by Paul Ganssle in [gh-103857](https://github.com/python/cpython/issues/103857).)
- Replaced many long-deprecated [unittest](https://docs.python.org/dev/library/unittest.html#module-unittest) features: (assertEquals, assertNotEquals, assertRegexpMatches, assertRaisesRegexp). Reference - [unittest features doc](https://docs.python.org/dev/whatsnew/3.12.html#id3).